### PR TITLE
[ros2] Use message latching for state topics

### DIFF
--- a/apps/runner-cutter-app/lib/useCameraNode.ts
+++ b/apps/runner-cutter-app/lib/useCameraNode.ts
@@ -66,15 +66,6 @@ export default function useCameraNode(nodeName: string) {
     };
   }, [nodeName, rosbridgeNodeInfo, nodeConnected, nodeState]);
 
-  const getState = useCallback(async () => {
-    const result = await ros.callService(
-      `${nodeName}/get_state`,
-      "camera_control_interfaces/GetState",
-      {}
-    );
-    setNodeState(convertStateMessage(result.state));
-  }, [ros, nodeName, setNodeState]);
-
   const addLogMessage = useCallback(
     (logMessage: string) => {
       setLogMessages((prevLogMessages) => {
@@ -85,14 +76,11 @@ export default function useCameraNode(nodeName: string) {
     [setLogMessages]
   );
 
-  // Initial node state
+  // Initial node connected state
   useEffect(() => {
     const connected = ros.isNodeConnected(nodeName);
-    if (connected) {
-      getState();
-    }
     setNodeConnected(connected);
-  }, [ros, nodeName, getState, setNodeConnected]);
+  }, [ros, nodeName, setNodeConnected]);
 
   // Subscriptions
   useEffect(() => {
@@ -100,11 +88,6 @@ export default function useCameraNode(nodeName: string) {
       (connectedNodeName, connected) => {
         if (connectedNodeName === nodeName) {
           setNodeConnected(connected);
-          if (connected) {
-            getState();
-          } else {
-            setNodeState(INITIAL_STATE);
-          }
         }
       }
     );
@@ -113,6 +96,7 @@ export default function useCameraNode(nodeName: string) {
       `${nodeName}/state`,
       "camera_control_interfaces/State",
       (message) => {
+        console.log(`state sub message: ${JSON.stringify(message)}`);
         setNodeState(convertStateMessage(message));
       }
     );
@@ -134,7 +118,7 @@ export default function useCameraNode(nodeName: string) {
       stateSub.unsubscribe();
       logSub.unsubscribe();
     };
-  }, [ros, nodeName, getState, setNodeConnected, setNodeState, addLogMessage]);
+  }, [ros, nodeName, setNodeConnected, setNodeState, addLogMessage]);
 
   const startDevice = useCallback(() => {
     // Optimistically set device state to "connecting"

--- a/apps/runner-cutter-app/lib/useControlNode.ts
+++ b/apps/runner-cutter-app/lib/useControlNode.ts
@@ -20,23 +20,11 @@ export default function useControlNode(nodeName: string) {
     };
   }, [nodeName, rosbridgeNodeInfo, nodeConnected, nodeState]);
 
-  const getState = useCallback(async () => {
-    const result = await ros.callService(
-      `${nodeName}/get_state`,
-      "runner_cutter_control_interfaces/GetState",
-      {}
-    );
-    setNodeState(result.state);
-  }, [ros, nodeName, setNodeState]);
-
-  // Initial node state
+  // Initial node connected state
   useEffect(() => {
     const connected = ros.isNodeConnected(nodeName);
-    if (connected) {
-      getState();
-    }
     setNodeConnected(connected);
-  }, [ros, nodeName, getState, setNodeConnected]);
+  }, [ros, nodeName, setNodeConnected]);
 
   // Subscriptions
   useEffect(() => {
@@ -44,11 +32,6 @@ export default function useControlNode(nodeName: string) {
       (connectedNodeName, connected) => {
         if (connectedNodeName === nodeName) {
           setNodeConnected(connected);
-          if (connected) {
-            getState();
-          } else {
-            setNodeState(INITIAL_STATE);
-          }
         }
       }
     );
@@ -65,7 +48,7 @@ export default function useControlNode(nodeName: string) {
       onNodeConnectedSub.unsubscribe();
       stateSub.unsubscribe();
     };
-  }, [ros, nodeName, getState, setNodeConnected, setNodeState]);
+  }, [ros, nodeName, setNodeConnected, setNodeState]);
 
   const calibrate = useCallback(() => {
     ros.callService(`${nodeName}/calibrate`, "std_srvs/Trigger", {});

--- a/ros2/aioros2/aioros2/decorators/subscribe.py
+++ b/ros2/aioros2/aioros2/decorators/subscribe.py
@@ -3,6 +3,7 @@ from ._decorators import RosDefinition
 from .topic import RosTopic
 from rclpy.expand_topic_name import expand_topic_name
 
+
 class RosSubscription(RosDefinition):
     def raw_topic(namespace, idl, qos_queue, server_handler):
         return RosSubscription(RosTopic(namespace, idl, qos_queue), server_handler)
@@ -11,13 +12,10 @@ class RosSubscription(RosDefinition):
         self.topic = topic
         self.handler = server_handler
 
-
     def get_fqt(self, node_name, node_ns) -> RosTopic:
         """Returns a fully-qualified topic name for this topic's path under the passed node."""
         fully_qual = expand_topic_name(self.topic.path, node_name, node_ns)
         return RosTopic(fully_qual, self.topic.idl, self.topic.qos)
-    
-
 
 
 def subscribe(topic: Union[Any, str], idl: Union[Any, None] = None, qos_queue=10):
@@ -26,6 +24,5 @@ def subscribe(topic: Union[Any, str], idl: Union[Any, None] = None, qos_queue=10
             return RosSubscription.raw_topic(topic, idl, qos_queue, fn)
         else:
             return RosSubscription(topic, fn)
-
 
     return _subscribe

--- a/ros2/aioros2/aioros2/decorators/topic.py
+++ b/ros2/aioros2/aioros2/decorators/topic.py
@@ -1,13 +1,16 @@
-from typing import Any
+from typing import Any, Union
 from ._decorators import RosDefinition
+from rclpy.qos import QoSProfile
+
 
 class RosTopic(RosDefinition):
-    def __init__(self, namespace, msg_idl, qos) -> None:
+    def __init__(
+        self, namespace: str, msg_idl: Any, qos: Union[QoSProfile, int]
+    ) -> None:
         self.path = namespace
         self.idl = msg_idl
         self.qos = qos
 
 
-def topic(namespace: str, idl: Any, queue: int = 10):
-    return RosTopic(namespace, idl, queue)
-    
+def topic(namespace: str, idl: Any, qos: Union[QoSProfile, int] = 10):
+    return RosTopic(namespace, idl, qos)


### PR DESCRIPTION
Setting durability to Transient Local (QoSDurabilityPolicy.RMW_QOS_POLICY_DURABILITY_TRANSIENT_LOCAL) will persist samples for late joiners. With this, we no longer need to call get_state service on the frontend