### PR TITLE
[ros2][laser][helios] Manually set shutter

### DIFF
--- a/ros2/laser_control/src/dacs/helios.cpp
+++ b/ros2/laser_control/src/dacs/helios.cpp
@@ -62,6 +62,8 @@ void Helios::play(int fps, int pps, float transitionDurationMs) {
   fps = std::max(0, fps);
   // Helios max rate: 65535 pps
   pps = std::clamp(pps, 0, 65535);
+  // For Helios, we need to manually activate the shutter
+  heliosDac_.SetShutter(dacIdx_, true);
   playing_ = true;
 
   playbackThread_ = std::thread([this, fps, pps, transitionDurationMs]() {
@@ -80,6 +82,7 @@ void Helios::play(int fps, int pps, float transitionDurationMs) {
       }
     }
     heliosDac_.Stop(dacIdx_);
+    heliosDac_.SetShutter(dacIdx_, false);
   });
 }
 


### PR DESCRIPTION
Some laser devices (such as the Unity RAW) have a safety mechanism, the shutter, that needs to be opened. DACs typically set the shutter pin (pin 13 on the ILDA standard DB25 cable) automatically, but the Helios needs to be set manually.