### PR TITLE
[ros2][runner cutter control] Attempt to make calibration a bit more reliable by adding a very slight delay

### DIFF
--- a/ros2/runner_cutter_control/src/calibration/calibration.cpp
+++ b/ros2/runner_cutter_control/src/calibration/calibration.cpp
@@ -124,7 +124,10 @@ std::size_t Calibration::addCalibrationPoints(
       }
 
       laser_->setPoint(laserCoord.first, laserCoord.second);
-      // Give sufficient time for galvo to settle
+      // Give sufficient time for galvo to settle.
+      // TODO: This shouldn't be necessary in theory since getDetection waits
+      // for several frames before running detection, so we'll need to figure
+      // out why this helps.
       std::this_thread::sleep_for(std::chrono::duration<float>(0.1f));
 
       auto resultOpt{findPointCorrespondence(laserCoord)};

--- a/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -997,8 +997,8 @@ class RunnerCutterControlNode : public rclcpp::Node {
           get_logger(),
           "Aiming laser. Target camera pixel = (%d, %d), laser detected at = "
           "(%d, %d), dist = %f",
-          targetCameraPixel.first, targetCameraPixel.second,
-          targetCameraPixel.first, targetCameraPixel.second, dist);
+          targetCameraPixel.first, targetCameraPixel.second, laserPixel.first,
+          laserPixel.second, dist);
 
       if (dist <= pixelDistanceThreshold) {
         RCLCPP_INFO(get_logger(), "Correction successful");

--- a/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -879,6 +879,7 @@ class RunnerCutterControlNode : public rclcpp::Node {
   }
 
   void burnTarget(uint32_t targetTrackId, std::pair<float, float> laserCoord) {
+    LaserDetectionContext context{laser_, camera_};
     float burnTimeSecs{getParamBurnTimeSecs()};
     laser_->clearPoint();
     auto [r, g, b, i]{getParamBurnLaserColor()};
@@ -981,6 +982,11 @@ class RunnerCutterControlNode : public rclcpp::Node {
 
     while (!taskStopSignal_) {
       laser_->setPoint(currentLaserCoord.first, currentLaserCoord.second);
+      // Give sufficient time for galvo to settle.
+      // TODO: This shouldn't be necessary in theory since getDetection waits
+      // for several frames before running detection, so we'll need to figure
+      // out why this helps.
+      std::this_thread::sleep_for(std::chrono::duration<float>(0.1f));
       // Get detected camera pixel coord and camera-space position for laser
       auto detectResultOpt{detectLaser()};
       if (!detectResultOpt) {


### PR DESCRIPTION
Found that oftentimes the first two laser detections during aiming were giving the same pixel result, even though the laser coords are different, and adding the delay significantly mitigates the issue.

Also, made sure to minimize exposure during burn.