### PR TITLE
[ros2] Clean up c_cpp_properties.json

### DIFF
--- a/ros2/.vscode/c_cpp_properties.json
+++ b/ros2/.vscode/c_cpp_properties.json
@@ -1,21 +1,17 @@
 {
   "configurations": [
     {
-      "browse": {
-        "databaseFilename": "${default}",
-        "limitSymbolsToIncludedHeaders": false
-      },
-      "includePath": [
-        "/opt/ros/humble/include/**",
-        "/usr/include/**"
-      ],
       "name": "ROS",
-      "intelliSenseMode": "gcc-x64",
+      "intelliSenseMode": "${default}",
       "compilerPath": "/usr/bin/gcc",
+      "compileCommands": "${workspaceFolder}/build/compile_commands.json",
       "cStandard": "gnu11",
       "cppStandard": "c++17",
-      "configurationProvider": "ms-vscode.cmake-tools",
-      "compileCommands": "${workspaceFolder}/build/compile_commands.json"
+      "browse": {
+        "databaseFilename": "${default}",
+        "limitSymbolsToIncludedHeaders": true
+      },
+      "configurationProvider": "ms-vscode.cmake-tools"
     }
   ],
   "version": 4


### PR DESCRIPTION
- Changed intelliSenseMode to default so it works on arm64
- Set limitSymbolsToIncludedHeaders to true to prevent unnecessary scans
- Remove includePaths since we are using ROS2 generated compile_commands.json