### PR TITLE
[ros2][camera control] Clean up LUCID calibration process

### DIFF
--- a/ros2/camera_control/camera_control/camera/calibration.py
+++ b/ros2/camera_control/camera_control/camera/calibration.py
@@ -49,6 +49,11 @@ def calibrate_camera(
     else:
         raise Exception("Unsupported grid_type")
 
+    if len(mono_images) < 3:
+        raise Exception(
+            "At least 3 images are required to calculate the camera intrinsics"
+        )
+
     obj_points = []
     img_points = []
     for image in mono_images:
@@ -138,16 +143,23 @@ def create_blob_detector():
     return cv2.SimpleBlobDetector_create(params)
 
 
-def construct_extrinsic_matrix(rotation_vector, translation_vector):
+def construct_extrinsic_matrix(rvec, tvec):
     # Convert rotation vector to rotation matrix using Rodrigues' formula
-    R, _ = cv2.Rodrigues(rotation_vector)
+    R, _ = cv2.Rodrigues(rvec)
 
     # Create the extrinsic matrix
     extrinsic_matrix = np.eye(4)
     extrinsic_matrix[:3, :3] = R
-    extrinsic_matrix[:3, 3] = translation_vector
+    extrinsic_matrix[:3, 3] = tvec
 
     return extrinsic_matrix
+
+
+def extract_pose_from_extrinsic(extrinsic_matrix):
+    R = extrinsic_matrix[:3, :3]
+    tvec = extrinsic_matrix[:3, 3]
+    rvec, _ = cv2.Rodrigues(R)
+    return rvec, tvec
 
 
 def invert_extrinsic_matrix(extrinsic_matrix: np.ndarray):
@@ -195,45 +207,497 @@ def distort_pixel_coords(undistorted_pixel_coords, intrinsic_matrix, distortion_
     return distorted_pixel_coords
 
 
-if __name__ == "__main__":
-    parser = argparse.ArgumentParser(
-        description="Calculate camera intrinsics and distortion coefficients from images of a calibration pattern"
+def scale_grayscale_image(mono_image: np.ndarray) -> np.ndarray:
+    """
+    Scale a grayscale image so that it uses the full 8-bit range.
+
+    Args:
+        mono_image: Grayscale image to scale.
+
+    Returns:
+        np.ndarray: Scaled uint8 grayscale image.
+    """
+    # Convert to float to avoid overflow or underflow issues
+    mono_image = np.array(mono_image, dtype=np.float32)
+
+    # Find the minimum and maximum values in the image
+    min_val = np.min(mono_image)
+    max_val = np.max(mono_image)
+
+    # Normalize the image to the range 0 to 1
+    if max_val > min_val:
+        mono_image = (mono_image - min_val) / (max_val - min_val)
+    else:
+        mono_image = mono_image - min_val
+
+    # Scale to 0-255 and convert to uint8
+    mono_image = (mono_image * 255).astype(np.uint8)
+
+    return mono_image
+
+
+def _calc_intrinsics(
+    images_dir: str,
+    output_dir: str,
+    grid_size: Tuple[int, int] = (5, 4),
+    grid_type: int = cv2.CALIB_CB_SYMMETRIC_GRID,
+    blob_detector=create_blob_detector(),
+    show_undistorted=False,
+):
+    """
+    Calculate camera intrinsics given images of a calibration grid.
+
+    Args:
+        images_dir: Directory containing images of a calibration grid.
+        output_dir: Directory to write the intrinsic matrix and distortion coefficients.
+        grid_size (Tuple[int, int]): (# cols, # rows) of the calibration pattern.
+        grid_type (int): One of the following:
+            cv2.CALIB_CB_SYMMETRIC_GRID uses symmetric pattern of circles.
+            cv2.CALIB_CB_ASYMMETRIC_GRID uses asymmetric pattern of circles.
+            cv2.CALIB_CB_CLUSTERING uses a special algorithm for grid detection. It is more robust to perspective distortions but much more sensitive to background clutter.
+        blobDetector: Feature detector that finds blobs, like dark circles on light background. If None then a default implementation is used.
+    """
+    images_dir = os.path.expanduser(images_dir)
+    output_dir = os.path.expanduser(output_dir)
+
+    image_paths = sorted(
+        glob(os.path.join(images_dir, "*.jpg"))
+        + glob(os.path.join(images_dir, "*.png"))
     )
-    parser.add_argument(
+    images = [
+        scale_grayscale_image(cv2.imread(image_path, cv2.IMREAD_GRAYSCALE))
+        for image_path in image_paths
+    ]
+    intrinsic_matrix, distortion_coeffs = calibrate_camera(
+        images,
+        grid_size,
+        grid_type,
+        blob_detector,
+    )
+
+    print(f"Calibrated intrins: {intrinsic_matrix}")
+    print(f"Distortion coeffs: {distortion_coeffs}")
+
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    np.save(
+        os.path.join(output_dir, "intrinsic_matrix.npy"),
+        intrinsic_matrix,
+    )
+    np.save(
+        os.path.join(output_dir, "distortion_coeffs.npy"),
+        distortion_coeffs,
+    )
+
+    if show_undistorted:
+        # Visual check of the intrinsic matrix and distortion coefficients by showing the undistorted image
+        for image in images:
+            h, w = image.shape[:2]
+            newcameramtx, roi = cv2.getOptimalNewCameraMatrix(
+                intrinsic_matrix, distortion_coeffs, (w, h), 1, (w, h)
+            )
+            undistorted_img = cv2.undistort(
+                image, intrinsic_matrix, distortion_coeffs, None, newcameramtx
+            )
+            # Crop the image
+            x, y, w, h = roi
+            undistorted_img = undistorted_img[y : y + h, x : x + w]
+            cv2.imshow("undistorted", undistorted_img)
+            cv2.waitKey(0)
+            cv2.destroyAllWindows()
+
+
+def _calc_extrinsics(
+    camera_images_dir: str,
+    helios_images_dir: str,
+    helios_xyz_dir: str,
+    camera_intrinsic_matrix_file: str,
+    camera_distortion_coeffs_file: str,
+    output_dir: str,
+    grid_size: Tuple[int, int] = (5, 4),
+    grid_type: int = cv2.CALIB_CB_SYMMETRIC_GRID,
+    blob_detector=create_blob_detector(),
+):
+    """
+    Calculate the extrinsic matrix given images of a calibration grid.
+    `camera_images_dir`, `helios_images_dir`, and `helios_xyz_dir` must contain files with the same
+    base name, which is how we form image correspondences. Images/files with the same base name
+    should be of the calibration grid in the identical position.
+
+    Args:
+        camera_images_dir: Directory containing images of a calibration grid taken by the target camera.
+        helios_images_dir: Directory containing Helios intensity images of a calibration grid.
+        helios_xyz_dir: Directory containing Helios XYZ .npy files of a calibration grid.
+        camera_intrinsic_matrix_file: File path to the target camera's intrinsic matrix (.npy file).
+        camera_distortion_coeffs_file: File path to the target camera's distortion coefficients (.npy file).
+        output_dir: Directory to write the intrinsic matrix and distortion coefficients.
+        grid_size (Tuple[int, int]): (# cols, # rows) of the calibration pattern.
+        grid_type (int): One of the following:
+            cv2.CALIB_CB_SYMMETRIC_GRID uses symmetric pattern of circles.
+            cv2.CALIB_CB_ASYMMETRIC_GRID uses asymmetric pattern of circles.
+            cv2.CALIB_CB_CLUSTERING uses a special algorithm for grid detection. It is more robust to perspective distortions but much more sensitive to background clutter.
+        blobDetector: Feature detector that finds blobs, like dark circles on light background. If None then a default implementation is used.
+    """
+    camera_images_dir = os.path.expanduser(camera_images_dir)
+    helios_images_dir = os.path.expanduser(helios_images_dir)
+    helios_xyz_dir = os.path.expanduser(helios_xyz_dir)
+    camera_intrinsic_matrix_file = os.path.expanduser(camera_intrinsic_matrix_file)
+    camera_distortion_coeffs_file = os.path.expanduser(camera_distortion_coeffs_file)
+    output_dir = os.path.expanduser(output_dir)
+
+    intrinsic_matrix = np.load(camera_intrinsic_matrix_file)
+    distortion_coeffs = np.load(camera_distortion_coeffs_file)
+
+    # Find all images in the target camera's images dir
+    camera_image_paths = sorted(
+        glob(os.path.join(os.path.expanduser(camera_images_dir), "*.jpg"))
+        + glob(os.path.join(os.path.expanduser(camera_images_dir), "*.png"))
+    )
+
+    circle_coords = []
+    circle_xyz_positions = []
+
+    # For each image in the camera images dir, find the corresponding Helios intensity image and XYZ image
+    for camera_image_path in camera_image_paths:
+        base_name = os.path.splitext(os.path.basename(camera_image_path))[0]
+
+        # Look for matching image in helios_images_dir
+        helios_image_path = None
+        for ext in [".jpg", ".png"]:
+            candidate = os.path.join(helios_images_dir, base_name + ext)
+            if os.path.exists(os.path.join(helios_images_dir, base_name + ext)):
+                helios_image_path = candidate
+                break
+
+        # Look for matching xyz file in helios_xyz_dir
+        helios_xyz_path = os.path.join(helios_xyz_dir, base_name + ".npy")
+
+        if helios_image_path and os.path.exists(helios_xyz_path):
+            print(f"Processing {base_name}:")
+            print(f"  Camera image file: {camera_image_path}")
+            print(f"  Helios image file: {helios_image_path}")
+            print(f"  Helios xyz file:  {helios_xyz_path}")
+
+            # Get circle centers in the camera image
+            camera_image = scale_grayscale_image(
+                cv2.imread(camera_image_path, cv2.IMREAD_GRAYSCALE)
+            )
+            retval, current_circle_coords = cv2.findCirclesGrid(
+                camera_image, grid_size, flags=grid_type, blobDetector=blob_detector
+            )
+            if not retval:
+                print("Could not get circle centers from the target camera's image.")
+                continue
+            current_circle_coords = np.squeeze(current_circle_coords)
+            circle_coords.append(current_circle_coords)
+
+            # Get Helios circle centers
+            helios_image = scale_grayscale_image(
+                cv2.imread(helios_image_path, cv2.IMREAD_GRAYSCALE)
+            )
+            retval, current_helios_circle_coords = cv2.findCirclesGrid(
+                helios_image, grid_size, flags=grid_type, blobDetector=blob_detector
+            )
+            if not retval:
+                print("Could not get circle centers from Helios intensity image.")
+                continue
+            current_helios_circle_coords = np.squeeze(
+                np.round(current_helios_circle_coords).astype(np.int32)
+            )
+
+            # Get XYZ values from the Helios 3D image that match 2D locations on the target camera (corresponding points)
+            helios_xyz = np.load(helios_xyz_path)
+            current_circle_xyz_positions = helios_xyz[
+                current_helios_circle_coords[:, 1], current_helios_circle_coords[:, 0]
+            ]
+            circle_xyz_positions.append(current_circle_xyz_positions)
+
+    if len(circle_coords) == 0 or len(circle_xyz_positions) == 0:
+        print("No suitable correspondences found")
+        return
+
+    circle_coords = np.concatenate(circle_coords, axis=0)
+    circle_xyz_positions = np.concatenate(circle_xyz_positions, axis=0)
+
+    retval, rvec, tvec = cv2.solvePnP(
+        circle_xyz_positions,
+        circle_coords,
+        intrinsic_matrix,
+        distortion_coeffs,
+        flags=cv2.SOLVEPNP_ITERATIVE,
+    )
+    """
+    retval, rvec, tvec, inliers = cv2.solvePnPRansac(
+        circle_xyz_positions,
+        circle_coords,
+        intrinsic_matrix,
+        distortion_coeffs,
+        flags=cv2.SOLVEPNP_ITERATIVE,
+        reprojectionError=4.0,
+        confidence=0.999,
+    )
+    """
+    if not retval:
+        print("Could not calculate extrinsic matrix.")
+        return
+
+    # Calculate reprojection error
+    reprojected, _ = cv2.projectPoints(
+        circle_xyz_positions,
+        rvec,
+        tvec,
+        intrinsic_matrix,
+        distortion_coeffs,
+    )
+    # Flatten projected points to (N, 2)
+    reprojected = reprojected.reshape(-1, 2)
+    errors = np.linalg.norm(circle_coords - reprojected, axis=1)
+
+    # Mean reprojection error
+    mean_error = np.mean(errors)
+    print("Reprojection error (mean):", mean_error)
+
+    rvec = rvec.flatten()
+    tvec = tvec.flatten()
+    extrinsic_matrix = construct_extrinsic_matrix(rvec, tvec)
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+    np.save(
+        os.path.join(output_dir, "extrinsic_matrix.npy"),
+        extrinsic_matrix,
+    )
+
+
+def _visualize_extrinsics(
+    camera_mono_image_file: str,
+    helios_intensity_image_file: str,
+    helios_xyz_file: str,
+    camera_intrinsic_matrix_file: str,
+    camera_distortion_coeffs_file: str,
+    xyz_to_camera_extrinsic_matrix_file: str,
+):
+    camera_mono_image_file = os.path.expanduser(camera_mono_image_file)
+    helios_intensity_image_file = os.path.expanduser(helios_intensity_image_file)
+    helios_xyz_file = os.path.expanduser(helios_xyz_file)
+    camera_intrinsic_matrix_file = os.path.expanduser(camera_intrinsic_matrix_file)
+    camera_distortion_coeffs_file = os.path.expanduser(camera_distortion_coeffs_file)
+    xyz_to_camera_extrinsic_matrix_file = os.path.expanduser(
+        xyz_to_camera_extrinsic_matrix_file
+    )
+
+    helios_xyz = np.load(helios_xyz_file)
+    camera_intrinsic_matrix = np.load(camera_intrinsic_matrix_file)
+    camera_distortion_coeffs = np.load(camera_distortion_coeffs_file)
+    xyz_to_camera_extrinsic_matrix = np.load(xyz_to_camera_extrinsic_matrix_file)
+    camera_mono_image = scale_grayscale_image(
+        cv2.imread(camera_mono_image_file, cv2.IMREAD_GRAYSCALE)
+    )
+    helios_intensity_image = scale_grayscale_image(
+        cv2.imread(helios_intensity_image_file, cv2.IMREAD_GRAYSCALE)
+    )
+
+    rvec, tvec = extract_pose_from_extrinsic(xyz_to_camera_extrinsic_matrix)
+    h, w, c = helios_xyz.shape
+    object_points = helios_xyz.reshape(h * w, c)
+    projected_points, _ = cv2.projectPoints(
+        object_points, rvec, tvec, camera_intrinsic_matrix, camera_distortion_coeffs
+    )
+    projected_points = projected_points.reshape(-1, 2)
+
+    # Render camera frame as red
+    camera_h, camera_w = camera_mono_image.shape
+    projection_img = np.zeros((camera_h, camera_w, 3), dtype=np.uint8)
+    projection_img[camera_mono_image < 100] = [0, 0, 128]  # red
+
+    # Render XYZ as green
+    # For every pixel in the depth frame, render the xyz projected onto the camera image plane.
+    # Only render if the intensity is lower than a certain threshold so that the grid circles are
+    # visible.
+    helios_intensity_image = helios_intensity_image.flatten()
+    for point_idx in range(h * w):
+        point = projected_points[point_idx]
+        col = round(point[0])
+        row = round(point[1])
+        if 0 <= col and col < camera_w and 0 <= row and row < camera_h:
+            intensity = helios_intensity_image[point_idx]
+            thresh = 1 if intensity < 30 else 0
+            projection_img[row][col][1] = thresh * 255  # green overlay
+
+    cv2.namedWindow("projection", cv2.WINDOW_NORMAL)
+    cv2.imshow("projection", projection_img)
+    cv2.resizeWindow("projection", 800, 600)
+    cv2.waitKey(0)
+    cv2.destroyAllWindows()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(title="Available Commands", dest="command")
+
+    calc_intrinsics_parser = subparsers.add_parser(
+        "calc_intrinsics",
+        help="Calculate camera intrinsics and distortion coefficients from images of a calibration pattern",
+    )
+    calc_intrinsics_parser.add_argument(
         "-i",
-        "--input_dir",
+        "--images_dir",
+        type=str,
+        default=None,
         required=True,
-        help="Path to the directory containing images of a calibration pattern",
+        help="Path to the directory containing grayscale images of a calibration pattern",
+    )
+    calc_intrinsics_parser.add_argument(
+        "-o",
+        "--output_dir",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to the directory to write intrinsic parameters to",
+    )
+    calc_intrinsics_parser.add_argument(
+        "-s",
+        "--show_undistorted",
+        action="store_true",
+        help="Show undistorted versions of input images",
+    )
+
+    calc_extrinsics_xyz_to_triton_parser = subparsers.add_parser(
+        "calc_extrinsics_xyz_to_triton",
+        help="Calculate extrinsics that describe the orientation of Triton relative to Helios XYZ from images of a calibration pattern",
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_images_dir", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "--helios_images_dir", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "--helios_xyz_dir", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_intrinsic_matrix_file", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_distortion_coeffs_file", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_triton_parser.add_argument(
+        "-o",
+        "--output_dir",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to the directory to write extrinsic parameters to",
+    )
+
+    calc_extrinsics_xyz_to_helios_parser = subparsers.add_parser(
+        "calc_extrinsics_xyz_to_helios",
+        help="Calculate extrinsics that describe the orientation of Helios intensity relative to Helios XYZ from images of a calibration pattern",
+    )
+    calc_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_images_dir", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_xyz_dir", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_intrinsic_matrix_file", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_distortion_coeffs_file", type=str, default=None, required=True
+    )
+    calc_extrinsics_xyz_to_helios_parser.add_argument(
+        "-o",
+        "--output_dir",
+        type=str,
+        default=None,
+        required=True,
+        help="Path to the directory to write extrinsic parameters to",
+    )
+
+    visualize_extrinsics_xyz_to_triton_parser = subparsers.add_parser(
+        "visualize_extrinsics_xyz_to_triton",
+        help="Verify extrinsics between Triton and Helios XYZ by projecting XYZ onto Triton image",
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_mono_image", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--helios_intensity_image", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--helios_xyz", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_intrinsic_matrix_file", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--triton_distortion_coeffs_file", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_triton_parser.add_argument(
+        "--xyz_to_triton_extrinsic_matrix_file", type=str, default=None, required=True
+    )
+
+    visualize_extrinsics_xyz_to_helios_parser = subparsers.add_parser(
+        "visualize_extrinsics_xyz_to_helios",
+        help="Verify extrinsics between Helios intensity and Helios XYZ by projecting XYZ onto Helios intensity image",
+    )
+    visualize_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_intensity_image", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_xyz", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_intrinsic_matrix_file", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_helios_parser.add_argument(
+        "--helios_distortion_coeffs_file", type=str, default=None, required=True
+    )
+    visualize_extrinsics_xyz_to_helios_parser.add_argument(
+        "--xyz_to_helios_extrinsic_matrix_file", type=str, default=None, required=True
     )
 
     args = parser.parse_args()
-    image_paths = sorted(
-        glob(os.path.join(args.input_dir, "*.jpg"))
-        + glob(os.path.join(args.input_dir, "*.png"))
-    )
-    images = [
-        cv2.cvtColor(cv2.imread(image_path), cv2.COLOR_RGB2GRAY)
-        for image_path in image_paths
-    ]
-    camera_matrix, dist_coeffs = calibrate_camera(
-        images,
-        (5, 4),
-        grid_type=cv2.CALIB_CB_SYMMETRIC_GRID,
-        blob_detector=create_blob_detector(),
-    )
-    print(f"Calibrated intrins: {camera_matrix}")
-    print(f"Distortion coeffs: {dist_coeffs}")
 
-    # Test calibration
-    img = images[10]
-    h, w = img.shape[:2]
-    newcameramtx, roi = cv2.getOptimalNewCameraMatrix(
-        camera_matrix, dist_coeffs, (w, h), 1, (w, h)
-    )
-    undistorted_img = cv2.undistort(img, camera_matrix, dist_coeffs, None, newcameramtx)
-    # crop the image
-    x, y, w, h = roi
-    undistorted_img = undistorted_img[y : y + h, x : x + w]
-    cv2.imshow("undistorted", undistorted_img)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
+    if args.command == "calc_intrinsics":
+        _calc_intrinsics(
+            args.images_dir, args.output_dir, show_undistorted=args.show_undistorted
+        )
+    elif args.command == "calc_extrinsics_xyz_to_triton":
+        _calc_extrinsics(
+            args.triton_images_dir,
+            args.helios_images_dir,
+            args.helios_xyz_dir,
+            args.triton_intrinsic_matrix_file,
+            args.triton_distortion_coeffs_file,
+            args.output_dir,
+        )
+    elif args.command == "calc_extrinsics_xyz_to_helios":
+        _calc_extrinsics(
+            args.helios_images_dir,
+            args.helios_images_dir,
+            args.helios_xyz_dir,
+            args.helios_intrinsic_matrix_file,
+            args.helios_distortion_coeffs_file,
+            args.output_dir,
+        )
+    elif args.command == "visualize_extrinsics_xyz_to_triton":
+        _visualize_extrinsics(
+            args.triton_mono_image,
+            args.helios_intensity_image,
+            args.helios_xyz,
+            args.triton_intrinsic_matrix_file,
+            args.triton_distortion_coeffs_file,
+            args.xyz_to_triton_extrinsic_matrix_file,
+        )
+    elif args.command == "visualize_extrinsics_xyz_to_helios":
+        _visualize_extrinsics(
+            args.helios_intensity_image,
+            args.helios_intensity_image,
+            args.helios_xyz,
+            args.helios_intrinsic_matrix_file,
+            args.helios_distortion_coeffs_file,
+            args.xyz_to_helios_extrinsic_matrix_file,
+        )
+    else:
+        print("Invalid command.")

--- a/ros2/camera_control/camera_control/camera/lucid_camera.py
+++ b/ros2/camera_control/camera_control/camera/lucid_camera.py
@@ -3,7 +3,10 @@ import concurrent.futures
 import ctypes
 import logging
 import os
+import shutil
+import subprocess
 import sys
+import tempfile
 import threading
 import time
 from enum import Enum, auto
@@ -15,14 +18,9 @@ from ament_index_python.packages import get_package_share_directory
 from arena_api.enums import PixelFormat
 from arena_api.system import system
 
-from .calibration import construct_extrinsic_matrix, create_blob_detector
 from .lucid_frame import LucidFrame
 from .rgbd_camera import RgbdCamera, State
 from .rgbd_frame import RgbdFrame
-
-import subprocess
-import shutil
-import tempfile
 
 COLOR_CAMERA_MODEL_PREFIXES = ["ATL", "ATX", "PHX", "TRI", "TRT"]
 DEPTH_CAMERA_MODEL_PREFIXES = ["HTP", "HLT", "HTR", "HTW"]
@@ -38,105 +36,6 @@ class CaptureMode(Enum):
     CONTINUOUS_PTP = (
         auto()
     )  # Continuous capture, with cameras synced using Precision Time Protocol
-
-
-def scale_grayscale_image(mono_image: np.ndarray) -> np.ndarray:
-    """
-    Scale a grayscale image so that it uses the full 8-bit range.
-
-    Args:
-        mono_image: Grayscale image to scale.
-
-    Returns:
-        np.ndarray: Scaled uint8 grayscale image.
-    """
-    # Convert to float to avoid overflow or underflow issues
-    mono_image = np.array(mono_image, dtype=np.float32)
-
-    # Find the minimum and maximum values in the image
-    min_val = np.min(mono_image)
-    max_val = np.max(mono_image)
-
-    # Normalize the image to the range 0 to 1
-    if max_val > min_val:
-        mono_image = (mono_image - min_val) / (max_val - min_val)
-    else:
-        mono_image = mono_image - min_val
-
-    # Scale to 0-255 and convert to uint8
-    mono_image = (mono_image * 255).astype(np.uint8)
-
-    return mono_image
-
-
-def get_extrinsics(
-    triton_mono_image: np.ndarray,
-    helios_intensity_image: np.ndarray,
-    helios_xyz_image: np.ndarray,
-    triton_intrinsic_matrix: np.ndarray,
-    triton_distortion_coeffs: np.ndarray,
-    grid_size: Tuple[int, int],
-    grid_type: int = cv2.CALIB_CB_SYMMETRIC_GRID,
-    blob_detector=None,
-) -> Tuple[Optional[np.ndarray], Optional[np.ndarray]]:
-    """
-    Finds the rotation and translation vectors that describe the conversion from Helios 3D coordinates
-    to the Triton camera's coordinate system.
-
-    Args:
-        triton_mono_image (np.ndarray): Grayscale image from a Triton camera containing the calibration pattern.
-        helios_intensity_image (np.ndarray): Grayscale image from a Helios camera containing the calibration pattern.
-        helios_xyz_image (np.ndarray): 3D data from a Helios camera corresponding to helios_intensity_image
-        triton_intrinsic_matrix (np.ndarray): Intrinsic matrix of the Triton camera.
-        triton_distortion_coeffs: (np.ndarray): Distortion coefficients of the Triton camera.
-        grid_size (Tuple[int, int]): (# cols, # rows) of the calibration pattern.
-        grid_type (int): One of the following:
-            cv2.CALIB_CB_SYMMETRIC_GRID uses symmetric pattern of circles.
-            cv2.CALIB_CB_ASYMMETRIC_GRID uses asymmetric pattern of circles.
-            cv2.CALIB_CB_CLUSTERING uses a special algorithm for grid detection. It is more robust to perspective distortions but much more sensitive to background clutter.
-        blobDetector: Feature detector that finds blobs, like dark circles on light background. If None then a default implementation is used.
-
-    Returns:
-        Tuple[Optional[np.ndarray], Optional[np.ndarray]]: A tuple of (rotation vector, translation vector), or (None, None) if unsuccessful.
-    """
-    # Based on https://support.thinklucid.com/app-note-helios-3d-point-cloud-with-rgb-color/
-
-    # Scale images so that they each use the full 8-bit range
-    triton_mono_image = scale_grayscale_image(triton_mono_image)
-    helios_intensity_image = scale_grayscale_image(helios_intensity_image)
-
-    # Find calibration circle centers on both cameras
-    retval, triton_circle_centers = cv2.findCirclesGrid(
-        triton_mono_image, grid_size, flags=grid_type, blobDetector=blob_detector
-    )
-    if not retval:
-        print("Could not get circle centers from Triton mono image.")
-        return None, None
-    triton_circle_centers = np.squeeze(np.round(triton_circle_centers))
-
-    retval, helios_circle_centers = cv2.findCirclesGrid(
-        helios_intensity_image, grid_size, flags=grid_type, blobDetector=blob_detector
-    )
-    if not retval:
-        print("Could not get circle centers from Helios intensity image.")
-        return None, None
-    helios_circle_centers = np.squeeze(np.round(helios_circle_centers).astype(np.int32))
-
-    # Get XYZ values from the Helios 3D image that match 2D locations on the Triton (corresponding points)
-    helios_circle_positions = helios_xyz_image[
-        helios_circle_centers[:, 1], helios_circle_centers[:, 0]
-    ]
-
-    retval, rvec, tvec = cv2.solvePnP(
-        helios_circle_positions,
-        triton_circle_centers,
-        triton_intrinsic_matrix,
-        triton_distortion_coeffs,
-    )
-    if retval:
-        return rvec, tvec
-    else:
-        return None, None
 
 
 class LucidRgbdCamera(RgbdCamera):
@@ -1211,95 +1110,6 @@ def _get_position(
     cv2.destroyAllWindows()
 
 
-def _get_extrinsic(
-    triton_mono_image_path, helios_intensity_image_path, helios_xyz_path, output_path
-):
-    output_path = os.path.expanduser(output_path)
-    calibration_params_dir = _get_calibration_params_dir()
-    triton_intrinsic_matrix = np.load(
-        os.path.join(calibration_params_dir, "triton_intrinsic_matrix.npy")
-    )
-    triton_distortion_coeffs = np.load(
-        os.path.join(calibration_params_dir, "triton_distortion_coeffs.npy")
-    )
-    triton_mono_image = np.load(os.path.expanduser(triton_mono_image_path))
-    helios_intensity_image = np.load(os.path.expanduser(helios_intensity_image_path))
-    helios_xyz = np.load(os.path.expanduser(helios_xyz_path))
-
-    rvec, tvec = get_extrinsics(
-        triton_mono_image,  # type: ignore
-        helios_intensity_image,  # type: ignore
-        helios_xyz,  # type: ignore
-        triton_intrinsic_matrix,  # type: ignore
-        triton_distortion_coeffs,  # type: ignore
-        (5, 4),
-        grid_type=cv2.CALIB_CB_SYMMETRIC_GRID,
-        blob_detector=create_blob_detector(),
-    )
-
-    rvec = rvec.flatten()
-    tvec = tvec.flatten()
-    helios3d_to_triton_extrinsic_matrix = construct_extrinsic_matrix(rvec, tvec)
-
-    output_dir = os.path.dirname(output_path)
-    if not os.path.exists(output_dir):
-        os.makedirs(output_dir)
-    np.save(
-        output_path,
-        helios3d_to_triton_extrinsic_matrix,
-    )
-
-
-def _test_project(triton_mono_image_path, helios_intensity_image_path, helios_xyz_path):
-    calibration_params_dir = _get_calibration_params_dir()
-    triton_intrinsic_matrix = np.load(
-        os.path.join(calibration_params_dir, "triton_intrinsic_matrix.npy")
-    )
-    triton_distortion_coeffs = np.load(
-        os.path.join(calibration_params_dir, "triton_distortion_coeffs.npy")
-    )
-    helios3d_to_triton_extrinsic_matrix = np.load(
-        os.path.join(calibration_params_dir, "helios3d_to_triton_extrinsic_matrix.npy")
-    )
-    triton_mono_image = np.load(os.path.expanduser(triton_mono_image_path))
-    helios_xyz = np.load(os.path.expanduser(helios_xyz_path))
-    helios_intensity_image = np.load(os.path.expanduser(helios_intensity_image_path))
-    h, w, c = helios_xyz.shape
-    object_points = helios_xyz.reshape(h * w, c)
-    depths = object_points[:, 2]
-    average_depth = np.mean(depths)
-    print(f"average_depth: {average_depth}")
-    helios_intensity_image = helios_intensity_image.flatten()
-    R = helios3d_to_triton_extrinsic_matrix[:3, :3]
-    t = helios3d_to_triton_extrinsic_matrix[:3, 3]
-    start = time.perf_counter()
-    image_points, jacobian = cv2.projectPoints(
-        object_points, R, t, triton_intrinsic_matrix, triton_distortion_coeffs
-    )  # (x, y), or (col, row)
-    print(f"projectPoints took {time.perf_counter()-start} s")
-    image_points = image_points.reshape(-1, 2)
-    triton_height = 1536
-    triton_width = 2048
-    projected_image = np.zeros((triton_height, triton_width, 3), dtype=np.uint8)
-    projected_image[:, :, 2] = (triton_mono_image < 100) * 128
-    start = time.perf_counter()
-    for point_idx in range(h * w):
-        point = image_points[point_idx]
-        col = round(point[0])
-        row = round(point[1])
-        if 0 <= col and col < triton_width and 0 <= row and row < triton_height:
-            intensity = helios_intensity_image[point_idx]
-            thresh = 1 if intensity < 30 else 0
-            projected_image[row][col][1] = thresh * 255
-    print(f"populate image took {time.perf_counter()-start} s")
-    projected_image = cv2.resize(
-        projected_image, (round(triton_width / 2), round(triton_height / 2))
-    )
-    cv2.imshow("projected", projected_image)
-    cv2.waitKey(0)
-    cv2.destroyAllWindows()
-
-
 def _test_transform_depth_pixel_to_color_pixel(
     depth_pixel, triton_mono_image_path, helios_intensity_image_path, helios_xyz_path
 ):
@@ -1310,8 +1120,8 @@ def _test_transform_depth_pixel_to_color_pixel(
     triton_distortion_coeffs = np.load(
         os.path.join(calibration_params_dir, "triton_distortion_coeffs.npy")
     )
-    helios3d_to_triton_extrinsic_matrix = np.load(
-        os.path.join(calibration_params_dir, "helios3d_to_triton_extrinsic_matrix.npy")
+    xyz_to_triton_extrinsic_matrix = np.load(
+        os.path.join(calibration_params_dir, "xyz_to_triton_extrinsic_matrix.npy")
     )
     triton_mono_image = np.load(os.path.expanduser(triton_mono_image_path))
     helios_xyz = np.load(os.path.expanduser(helios_xyz_path))
@@ -1338,7 +1148,7 @@ def _test_transform_depth_pixel_to_color_pixel(
         xyz_mm,
         triton_intrinsic_matrix,
         triton_distortion_coeffs,
-        helios3d_to_triton_extrinsic_matrix,
+        xyz_to_triton_extrinsic_matrix,
     )
     cv2.drawMarker(
         triton_image,
@@ -1399,21 +1209,6 @@ if __name__ == "__main__":
         help="Stream depth heatmap visualization to terminal using chafa",
     )
 
-    get_extrinsic_parser = subparsers.add_parser(
-        "get_extrinsic",
-        help="Calculate extrinsic matrix between Helios2 to Triton cameras",
-    )
-    get_extrinsic_parser.add_argument(
-        "--triton_mono_image", type=str, default=None, required=True
-    )
-    get_extrinsic_parser.add_argument(
-        "--helios_intensity_image", type=str, default=None, required=True
-    )
-    get_extrinsic_parser.add_argument(
-        "--helios_xyz", type=str, default=None, required=True
-    )
-    get_extrinsic_parser.add_argument("--output", type=str, default=None, required=True)
-
     get_position_parser = subparsers.add_parser(
         "get_position",
         help="Given pixel coordinates in the Triton image, calculate the 3D position",
@@ -1426,20 +1221,6 @@ if __name__ == "__main__":
         "--helios_intensity_image", type=str, default=None, required=True
     )
     get_position_parser.add_argument(
-        "--helios_xyz", type=str, default=None, required=True
-    )
-
-    test_project_xyz_to_color_parser = subparsers.add_parser(
-        "test_project_xyz_to_color",
-        help="Verify calibration between Triton and Helios by projecting Helios point cloud onto Triton image",
-    )
-    test_project_xyz_to_color_parser.add_argument(
-        "--triton_mono_image", type=str, default=None, required=True
-    )
-    test_project_xyz_to_color_parser.add_argument(
-        "--helios_intensity_image", type=str, default=None, required=True
-    )
-    test_project_xyz_to_color_parser.add_argument(
         "--helios_xyz", type=str, default=None, required=True
     )
 
@@ -1468,22 +1249,9 @@ if __name__ == "__main__":
         _get_heatmap_frame(args.output_dir)
     elif args.command == "stream_heatmap":
         _stream_heatmap_to_terminal()
-    elif args.command == "get_extrinsic":
-        _get_extrinsic(
-            args.triton_mono_image,
-            args.helios_intensity_image,
-            args.helios_xyz,
-            args.output,
-        )
     elif args.command == "get_position":
         _get_position(
             args.pixel,
-            args.triton_mono_image,
-            args.helios_intensity_image,
-            args.helios_xyz,
-        )
-    elif args.command == "test_project_xyz_to_color":
-        _test_project(
             args.triton_mono_image,
             args.helios_intensity_image,
             args.helios_xyz,


### PR DESCRIPTION
- Consolidated all logic to generate calibration params into calibration.py
- Add ability to calculate extrinsics using multiple image correspondences instead of a single image correspondence
- Add separate commands for each step of the calibration process

So, now, the way to generate all required calibration matrices is:
- Run calibration.py's `calc_intrinsics` command, once for Triton and once for Helios (using intensity images)
- Run calibration.py's `calc_extrinsics_xyz_to_triton` command
- [Optional] Run calibration.py's `visualize_extrinsics_xyz_to_triton` command for validation
- Run calibration.py's `calc_extrinsics_xyz_to_helios` command
- [Optional] Run calibration.py's `visualize_extrinsics_xyz_to_helios` command for validation