### PR TITLE
[ros2][runner cutter control] Save latest frame timestamp to Track and reset predictor at terminal states

### DIFF
--- a/ros2/runner_cutter_control/include/runner_cutter_control/tracking/track.hpp
+++ b/ros2/runner_cutter_control/include/runner_cutter_control/tracking/track.hpp
@@ -16,12 +16,13 @@ class Track {
   };
 
   explicit Track(uint32_t id, const PixelCoord& pixel, const Position& position,
-                 State state = State::PENDING,
+                 double timestampMs, State state = State::PENDING,
                  std::unique_ptr<Predictor> predictor = nullptr);
 
   uint32_t getId() const { return id_; };
   PixelCoord getPixel() const { return pixel_; };
   Position getPosition() const { return position_; };
+  double getTimestampMs() const { return timestampMs_; };
   State getState() const { return state_; };
   size_t getStateCount(State state) const;
   Predictor& getPredictor() { return *predictor_; }
@@ -29,12 +30,14 @@ class Track {
 
   void setPixel(const PixelCoord& pixel);
   void setPosition(const Position& position);
+  void setTimestampMs(double timestampMs);
   void setState(State state);
 
  private:
   uint32_t id_{0};
   PixelCoord pixel_;
   Position position_;
+  double timestampMs_;
   std::unordered_map<State, size_t> stateCount_;
   State state_{State::PENDING};
   std::unique_ptr<Predictor> predictor_;

--- a/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -948,19 +948,15 @@ class RunnerCutterControlNode : public rclcpp::Node {
       auto track{trackOpt.value()};
 
       // Fire tracking laser at target using predicted future position
-      // TODO: Determine actual latency
-      double estimatedCameraLatencyMs{100.0};
       double timestampMillis{
           std::chrono::duration<double, std::milli>(
               std::chrono::high_resolution_clock::now().time_since_epoch())
               .count()};
-      Position predictedPosition{track->getPredictor().predict(
-          timestampMillis + estimatedCameraLatencyMs)};
-      LaserCoord laserCoord{
+      Position predictedPosition{
+          track->getPredictor().predict(timestampMillis)};
+      LaserCoord predictedLaserCoord{
           calibration_->cameraPositionToLaserCoord(predictedPosition)};
-      track->getPredictor().reset();
-
-      laser_->setPoint(laserCoord);
+      laser_->setPoint(predictedLaserCoord);
       std::this_thread::sleep_for(std::chrono::milliseconds(1));
       laser_->clearPoint();
     }

--- a/ros2/runner_cutter_control/src/tracking/track.cpp
+++ b/ros2/runner_cutter_control/src/tracking/track.cpp
@@ -1,11 +1,13 @@
 #include "runner_cutter_control/tracking/track.hpp"
 
 Track::Track(uint32_t id, const PixelCoord& pixel, const Position& position,
-             Track::State state, std::unique_ptr<Predictor> predictor)
+             double timestampMs, Track::State state,
+             std::unique_ptr<Predictor> predictor)
     : id_{id},
       pixel_{pixel},
       position_{position},
-      predictor_(predictor ? std::move(predictor) : nullptr) {
+      timestampMs_{timestampMs},
+      predictor_{predictor ? std::move(predictor) : nullptr} {
   stateCount_ = {{Track::State::PENDING, 0},
                  {Track::State::ACTIVE, 0},
                  {Track::State::COMPLETED, 0},
@@ -30,3 +32,5 @@ void Track::setState(Track::State state) {
   state_ = state;
   stateCount_[state]++;
 }
+
+void Track::setTimestampMs(double timestampMs) { timestampMs_ = timestampMs; }

--- a/ros2/runner_cutter_control/src/tracking/tracker.cpp
+++ b/ros2/runner_cutter_control/src/tracking/tracker.cpp
@@ -114,6 +114,11 @@ void Tracker::processTrack(uint32_t trackId, Track::State newState) {
   if (newState == Track::State::PENDING) {
     pendingTracks_.push_back(track);
   }
+
+  // Reset the predictor if the track is COMPLETED or FAILED
+  if (newState == Track::State::COMPLETED || newState == Track::State::FAILED) {
+    track->getPredictor().reset();
+  }
 }
 
 void Tracker::clear() {

--- a/ros2/runner_cutter_control/src/tracking/tracker.cpp
+++ b/ros2/runner_cutter_control/src/tracking/tracker.cpp
@@ -58,11 +58,12 @@ std::shared_ptr<Track> Tracker::addTrack(uint32_t trackId,
     track = tracks_[trackId];
     track->setPixel(pixel);
     track->setPosition(position);
+    track->setTimestampMs(timestampMs);
   } else {
     // Create a new track and set as PENDING
-    track =
-        std::make_shared<Track>(trackId, pixel, position, Track::State::PENDING,
-                                std::make_unique<KalmanFilterPredictor>());
+    track = std::make_shared<Track>(trackId, pixel, position, timestampMs,
+                                    Track::State::PENDING,
+                                    std::make_unique<KalmanFilterPredictor>());
     tracks_[trackId] = track;
     pendingTracks_.push_back(track);
   }


### PR DESCRIPTION
- Save latest frame timestamp to Track
- Add additional value checks in LucidFrame.get_corresponding_depth_pixel
- Reset predictor if track is completed or failed