### PR TITLE
[ros2][livekit] Modify Docker Compose network configuration to fix ICE gathering

### DIFF
--- a/ros2/livekit_ros2/config/ingress_server.yaml
+++ b/ros2/livekit_ros2/config/ingress_server.yaml
@@ -1,3 +1,10 @@
-ws_url: ws://server:7880
+ws_url: ws://127.0.0.1:7880
 redis:
-  address: redis:6379
+  address: 127.0.0.1:6379
+rtmp_port: 1935
+whip_port: 8085
+http_relay_port: 9095
+rtc_config:
+  udp_port: 7885
+  tcp_port: 7886 # optional TCP ICE fallback
+  use_external_ip: true # advertise public IP discovered via STUN

--- a/ros2/livekit_ros2/config/livekit_server.yaml
+++ b/ros2/livekit_ros2/config/livekit_server.yaml
@@ -4,7 +4,7 @@ rtc:
   tcp_port: 7881
   udp_port: 7882
 redis:
-  address: redis:6379
+  address: 127.0.0.1:6379
 ingress:
   rtmp_base_url: rtmp://localhost:1935
-  whip_base_url: http://localhost:8080/whip
+  whip_base_url: http://localhost:8085/whip

--- a/ros2/livekit_ros2/docker-compose.yaml
+++ b/ros2/livekit_ros2/docker-compose.yaml
@@ -2,35 +2,29 @@ services:
   redis:
     image: redis:7
     container_name: lk-redis
-    ports:
-      - "6379:6379"
+    network_mode: host
 
   server:
     image: livekit/livekit-server:latest
     container_name: lk-server
+    network_mode: host
     depends_on:
       - redis
     command: ["--config", "/config/livekit_server.yaml"]
     volumes:
       - ./config:/config:ro
-    ports:
-      - "7880:7880/tcp" # HTTP & WS
-      - "7881:7881/tcp" # TCP relay (optional)
-      - "7882:7882/udp" # UDP media
     env_file:
       - ../../.env # uses LIVEKIT_KEYS
 
   ingress:
     image: livekit/ingress:latest
     container_name: lk-ingress
+    network_mode: host
     depends_on:
       - server
       - redis
     command: ["--config", "/config/ingress_server.yaml"]
     volumes:
       - ./config:/config:ro
-    ports:
-      - "1935:1935/tcp" # RTMP ingest
-      - "8080:8080/tcp" # WHIP endpoint
     env_file:
       - ../../.env # uses LIVEKIT_API_KEY / LIVEKIT_API_SECRET


### PR DESCRIPTION
We were running into issues where sometimes, HTTP POST to the WHIP endpoint would return a 503. Digging further, we found that this was caused by ICE gathering timing out on the LiveKit Ingress server. The Ingress server uses UDP/7885 for ICE, but being in a Docker container was causing issues. I confirmed this by monitoring `sudo tcpdump -i any -vv -n udp port 7885`.

The main changes are:
- Set network_mode: host on the ingress server, as ICE over UDP has issues with the Docker NAT.
- Set the HTTP relay port on the ingress server to 9095 to avoid conflicts with the rosbridge server

I'm uncertain why the WHIP POST seemed to succeed most of the time (I was only able to reproduce ~1 in 10 times, and only on the Orin), but we should no longer run into 503s due to ICE gathering timeouts on the Ingress server.