### PR TITLE
[ros2][runner cutter control] Fix bug in camera-laser Jacobian calculation

### DIFF
--- a/ros2/runner_cutter_control/src/calibration/calibration.cpp
+++ b/ros2/runner_cutter_control/src/calibration/calibration.cpp
@@ -113,11 +113,12 @@ LaserCoord Calibration::cameraPositionToLaserCoord(
 
 LaserCoord Calibration::cameraPixelDeltaToLaserCoordDelta(
     const PixelCoord& cameraPixelCoordDelta) const {
-  auto jacobian{pointCorrespondences_.getCameraPixelToLaserCoordJacobian()};
   Eigen::Vector2d cameraPixelDelta{
       static_cast<double>(cameraPixelCoordDelta.u),
       static_cast<double>(cameraPixelCoordDelta.v)};
-  Eigen::Vector2d laserCoordDelta{jacobian * cameraPixelDelta};
+  Eigen::Vector2d laserCoordDelta{
+      pointCorrespondences_.getCameraPixelToLaserCoordJacobian() *
+      cameraPixelDelta};
   return {static_cast<float>(laserCoordDelta[0]),
           static_cast<float>(laserCoordDelta[1])};
 }

--- a/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -1103,12 +1103,14 @@ class RunnerCutterControlNode : public rclcpp::Node {
           calibration_->cameraPixelDeltaToLaserCoordDelta(cameraPixelDelta)};
       LaserCoord newLaserCoord{currentLaserCoord.x + laserCoordCorrection.x,
                                currentLaserCoord.y + laserCoordCorrection.y};
-      RCLCPP_INFO(
-          get_logger(),
-          "Distance too large. Correcting laser. Current laser coord = (%f, "
-          "%f), corrected laser coord = (%f, %f)",
-          currentLaserCoord.x, currentLaserCoord.y, newLaserCoord.x,
-          newLaserCoord.y);
+      RCLCPP_INFO(get_logger(),
+                  "Distance too large. Correcting laser. Camera pixel delta = "
+                  "(%d, %d), laser coord correction = (%f, %f). Current laser "
+                  "coord = (%f, %f), corrected laser coord = (%f, %f)",
+                  cameraPixelDelta.u, cameraPixelDelta.v,
+                  laserCoordCorrection.x, laserCoordCorrection.y,
+                  currentLaserCoord.x, currentLaserCoord.y, newLaserCoord.x,
+                  newLaserCoord.y);
 
       if (newLaserCoord.x > 1.0f || newLaserCoord.y > 1.0f ||
           newLaserCoord.x < 0.0f || newLaserCoord.y < 0.0f) {


### PR DESCRIPTION
The previous approach completely left out the offset (aka the bias term) when solving least squares, which is not correct because neither the laser nor camera pixel coordinates are zero-centered. The fix is to include the bias for least squares.