### PR TITLE
[ml][runner seg] Keep ONNX export at FP32

### DIFF
--- a/ml/runner_segmentation_model/runner_segmentation/yolo.py
+++ b/ml/runner_segmentation_model/runner_segmentation/yolo.py
@@ -169,7 +169,15 @@ class Yolo:
                 result.show()  # display to screen
 
     def export_onnx(self):
-        self.model.export(format="onnx", device=0, imgsz=self.imgsz, dynamic=False, batch=1, half=True, simplify=True)
+        self.model.export(
+            format="onnx",
+            device=0,
+            imgsz=self.imgsz,
+            dynamic=False,
+            batch=1,
+            half=False, # Keep as FP32 for ONNX as we will convert to FP16 when transforming to TensorRT
+            simplify=True,
+        )
 
 
 def tuple_type(arg_string):


### PR DESCRIPTION
When we go from PT -> ONNX -> TensorRT, if we export to ONNX at FP16, this causes issues when we transform that into TensorRT using trtexec. So, we keep FP32 during export to ONNX.