### PR TITLE
[camera_control][lucid_camera.cpp] Hardware synchronization of cameras and strobe.

### DIFF
--- a/ros2/src/camera_control/include/camera_control/camera/lucid_camera.hpp
+++ b/ros2/src/camera_control/include/camera_control/camera/lucid_camera.hpp
@@ -19,7 +19,7 @@ class LucidCamera {
                                                              "HTR", "HTW"};
 
   enum class State { STREAMING, CONNECTING, DISCONNECTED };
-  enum class CaptureMode { CONTINUOUS, SINGLE_FRAME };
+  enum class CaptureMode { CONTINUOUS, SINGLE_FRAME, SYNCHRONIZED };
 
   struct Frame {
     sensor_msgs::msg::Image::UniquePtr colorImage;

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -306,15 +306,13 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
                                          "AcquisitionStartMode", "Normal");
   Arena::SetNodeValue<GenICam::gcstring>(depthDevice_->GetNodeMap(),
                                          "AcquisitionStartMode", "Normal");
-  // TODO: Once cameras are hardware synced via trigger signals, set appropriate
-  // packet delay and frame transmission delay. See
   // https://support.thinklucid.com/app-note-bandwidth-sharing-in-multi-camera-systems/
   // With packet size of 9000 bytes on a 1 Gbps link, the packet delay is:
   // (9000 bytes * 8 ns/byte) * 1.1 buffer = 79200 ns
-  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCFTD", 0);
+  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCFTD", 79200);
   Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCFTD", 0);
-  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCPD", 80);
-  Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCPD", 80);
+  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCPD", 79200);
+  Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCPD", 79200);
   // Select GPIO line to output strobe signal on color camera
   // See https://support.thinklucid.com/app-note-using-gpio-on-lucid-cameras/
   Arena::SetNodeValue<GenICam::gcstring>(
@@ -368,6 +366,7 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
       depthCameraSerialNumber_.value(), depthFrameSize_.first,
       depthFrameSize_.second);
   callStateChangeCallback();
+
 }
 
 void LucidCamera::setNetworkSettings(Arena::IDevice* device) {

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -324,15 +324,6 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
                                          "Output");
   Arena::SetNodeValue<GenICam::gcstring>(colorDevice_->GetNodeMap(),
                                          "LineSource", "ExposureActive");
-  Arena::SetNodeValue<GenICam::gcstring>(colorDevice_->GetNodeMap(),
-                                         "LineSelector",
-                                         "Line1");  // opto-isolated output
-  Arena::SetNodeValue<GenICam::gcstring>(colorDevice_->GetNodeMap(), "LineMode",
-                                         "Output");
-  Arena::SetNodeValue<GenICam::gcstring>(colorDevice_->GetNodeMap(),
-                                         "LineSource", "ExposureActive");
-  // TODO: Enable trigger mode on depth camera. See
-  // https://support.thinklucid.com/app-note-using-gpio-on-lucid-cameras/#config
 
   captureMode_ = captureMode;
   Arena::SetNodeValue<GenICam::gcstring>(
@@ -342,7 +333,16 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
       depthDevice_->GetNodeMap(), "AcquisitionMode",
       captureMode == CaptureMode::SINGLE_FRAME ? "SingleFrame" : "Continuous");
 
-  ////////////////////////
+  // Select GPIO line to take trigger signal from master (triton) to slave (helios)
+  // Line 0 chosen because its range covers 24V trigger signal
+  Arena::SetNodeValue<GenICam::gcstring>(
+      depthDevice_->GetNodeMap(), "TriggerSelector", "FrameStart");
+  Arena::SetNodeValue<GenICam::gcstring>(
+      depthDevice_->GetNodeMap(), "TriggerSource", "Line0"); // opto-isolated input
+  Arena::SetNodeValue<GenICam::gcstring>(
+      depthDevice_->GetNodeMap(), "TriggerMode", "On");
+  
+    ////////////////////////
   // Set exposure and gain
   ////////////////////////
   if (exposureUs) {

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -331,8 +331,8 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
 
   // Select GPIO line to take trigger signal from master (triton) to slave (helios)
   // Line 0 chosen because its range covers 24V trigger signal
-  // SYNCHRONIZED means cameras are synced at hardware level; unreachable until exposed by msg, inert for now
-  if (captureMode == CaptureMode::SYNCHRONIZED){
+  // SYNCHRONIZED means cameras are synced at hardware level; nothing sets this mode yet, inert for now.
+  if (captureMode == CaptureMode::SYNCHRONIZED) {
     Arena::SetNodeValue<GenICam::gcstring>(
       depthDevice_->GetNodeMap(), "TriggerSelector", "FrameStart");
     Arena::SetNodeValue<GenICam::gcstring>(
@@ -367,7 +367,6 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
       depthCameraSerialNumber_.value(), depthFrameSize_.first,
       depthFrameSize_.second);
   callStateChangeCallback();
-
 }
 
 void LucidCamera::setNetworkSettings(Arena::IDevice* device) {

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -307,12 +307,10 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
   Arena::SetNodeValue<GenICam::gcstring>(depthDevice_->GetNodeMap(),
                                          "AcquisitionStartMode", "Normal");
   // https://support.thinklucid.com/app-note-bandwidth-sharing-in-multi-camera-systems/
-  // With packet size of 9000 bytes on a 1 Gbps link, the packet delay is:
-  // (9000 bytes * 8 ns/byte) * 1.1 buffer = 79200 ns
-  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCFTD", 79200);
+  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCFTD", 0);
   Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCFTD", 0);
-  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCPD", 79200);
-  Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCPD", 79200);
+  Arena::SetNodeValue<int64_t>(colorDevice_->GetNodeMap(), "GevSCPD", 0);
+  Arena::SetNodeValue<int64_t>(depthDevice_->GetNodeMap(), "GevSCPD", 0);
   // Select GPIO line to output strobe signal on color camera
   // See https://support.thinklucid.com/app-note-using-gpio-on-lucid-cameras/
   Arena::SetNodeValue<GenICam::gcstring>(

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -331,7 +331,7 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
 
   // Select GPIO line to take trigger signal from master (triton) to slave (helios)
   // Line 0 chosen because its range covers 24V trigger signal
-  // SYNCHRONIZED means cameras are synced at hardware level; nothing sets this mode yet, inert for now.
+  // SYNCHRONIZED means cameras are synced at hardware level.
   if (captureMode == CaptureMode::SYNCHRONIZED) {
     Arena::SetNodeValue<GenICam::gcstring>(
       depthDevice_->GetNodeMap(), "TriggerSelector", "FrameStart");

--- a/ros2/src/camera_control/src/camera/lucid_camera.cpp
+++ b/ros2/src/camera_control/src/camera/lucid_camera.cpp
@@ -331,12 +331,15 @@ void LucidCamera::startStream(const Arena::DeviceInfo& colorDeviceInfo,
 
   // Select GPIO line to take trigger signal from master (triton) to slave (helios)
   // Line 0 chosen because its range covers 24V trigger signal
-  Arena::SetNodeValue<GenICam::gcstring>(
+  // SYNCHRONIZED means cameras are synced at hardware level; unreachable until exposed by msg, inert for now
+  if (captureMode == CaptureMode::SYNCHRONIZED){
+    Arena::SetNodeValue<GenICam::gcstring>(
       depthDevice_->GetNodeMap(), "TriggerSelector", "FrameStart");
-  Arena::SetNodeValue<GenICam::gcstring>(
+    Arena::SetNodeValue<GenICam::gcstring>(
       depthDevice_->GetNodeMap(), "TriggerSource", "Line0"); // opto-isolated input
-  Arena::SetNodeValue<GenICam::gcstring>(
+    Arena::SetNodeValue<GenICam::gcstring>(
       depthDevice_->GetNodeMap(), "TriggerMode", "On");
+  }
   
     ////////////////////////
   // Set exposure and gain


### PR DESCRIPTION
Opening this as a draft PR to track progress.

Currently cameras are synced with strobe with a master/slave protocol. Triton drives the strobe and depth camera frame capture at a hardware level.