### PR TITLE
[runner cutter app] Modify Amiga app registration to automatically set username

### DIFF
--- a/apps/runner-cutter-app/README.md
+++ b/apps/runner-cutter-app/README.md
@@ -38,8 +38,6 @@ Web app for laser runner cutter control and automation, built with Next.js.
 
 ### On Amiga Brain
 
-1.  Modify [manifest.json](manifest.json) and [scripts/amiga_run_app.sh](scripts/amiga_run_app.sh) to replace the username with yours.
-
 1.  To register the app in the Amiga Brain's app launcher, run:
 
         $ scripts/amiga_register.sh

--- a/apps/runner-cutter-app/manifest.json
+++ b/apps/runner-cutter-app/manifest.json
@@ -3,7 +3,7 @@
     "laser-runner-cutter-app": {
       "name": "laser-runner-cutter-app",
       "type": "app",
-      "exec_cmd": "/mnt/managed_home/farm-ng-user-genkikondo/laser-runner-cutter/apps/runner-cutter-app/scripts/amiga_run_app.sh",
+      "exec_cmd": "__EXEC_CMD__",
       "app_route": "3000",
       "display_name": "Laser Runner Cutter",
       "autostart": false

--- a/apps/runner-cutter-app/scripts/amiga_register.sh
+++ b/apps/runner-cutter-app/scripts/amiga_register.sh
@@ -13,11 +13,12 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 app_dir=$script_dir/..
 app_manifest_file=$app_dir/manifest.json
 user_manifest_file=~/manifest.json
+exec_cmd="$script_dir/amiga_run_app.sh"
 
 # If user manifest file does not exist, then just copy the app manifest file.
 # Otherwise, insert the services in the app manifest file into the user manifest file.
 if [ ! -f "$user_manifest_file" ]; then
-  cp $app_manifest_file $user_manifest_file
+  sed "s|__EXEC_CMD__|$exec_cmd|g" "$app_manifest_file" > "$user_manifest_file"
 else
   node <<EOF
 const fs = require('fs');
@@ -26,7 +27,7 @@ const appManifestFile = '$app_manifest_file';
 const userManifestFile = '$user_manifest_file';
 
 try {
-  const appManifestJson = JSON.parse(fs.readFileSync(appManifestFile, 'utf8'));
+  const appManifestJson = JSON.parse(fs.readFileSync(appManifestFile, 'utf8').replace(/__EXEC_CMD__/g, '$exec_cmd'));
   const userManifestJson = JSON.parse(fs.readFileSync(userManifestFile, 'utf8'));
 
   // Merge "services" objects

--- a/apps/runner-cutter-app/scripts/amiga_run_app.sh
+++ b/apps/runner-cutter-app/scripts/amiga_run_app.sh
@@ -1,13 +1,14 @@
 #!/bin/bash
 # For use by the Amiga Brain's launcher to launch the app.
 
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
 if ! command -v node &> /dev/null; then
-  # TODO: figure out a better way to run node when launched via systemd
-  export NVM_DIR="/mnt/managed_home/farm-ng-user-genkikondo/.nvm"
+  username=$(echo "$script_dir" | sed 's|/mnt/managed_home/\([^/]*\)/.*|\1|')
+  export NVM_DIR="/mnt/managed_home/$username/.nvm"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
 fi
 
-script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 app_dir=$script_dir/..
 
 cd $app_dir


### PR DESCRIPTION
Before, we needed to manually modify the manifest.json and amiga_run_app.sh to set the proper username. Now that is done automatically, via amiga_register.sh