### PR TITLE
[ros2] Tweak laser control params to max fps

### DIFF
--- a/ros2/src/runner_cutter_control/config/parameters.yaml
+++ b/ros2/src/runner_cutter_control/config/parameters.yaml
@@ -25,9 +25,10 @@ laser0:
   ros__parameters:
     dac_type: "helios"
     dac_index: 0
-    # Since we only render one point at a time, we want fps equal to pps and set as high as possible
-    # in order to minimize buffer size and thus latency.
-    fps: 1000
-    pps: 1000
-    transition_duration_ms: 0.5
+    # Since we only render one point at a time, we want fps equal to pps and set as high as
+    # possible in order to minimize buffer size and thus latency. Also, set transition_duration_ms
+    # (delay between points when rendering more than one) to 0
+    fps: 30000
+    pps: 30000
+    transition_duration_ms: 0.0
     color: [0.15, 0.0, 0.0, 0.0]

--- a/ros2/src/runner_cutter_control/config/parameters.yaml
+++ b/ros2/src/runner_cutter_control/config/parameters.yaml
@@ -3,6 +3,7 @@ control0:
     laser_control_node_name: "laser0"
     camera_control_node_name: "camera0"
     detection_node_name: "detection0"
+    calibration_grid_size: [11, 11]
     calibration_x_bounds: [0.25, 0.8]
     calibration_y_bounds: [0.45, 1.0]
     tracking_laser_color: [0.15, 0.0, 0.0, 0.0]
@@ -14,6 +15,7 @@ control0:
 camera0:
   ros__parameters:
     camera_index: 0
+    calibration_id: "1c0faf4b115d1c0faf4d17ce"
     exposure_us: 20000.0
     gain_db: 1.0
 detection0:

--- a/ros2/src/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/src/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -50,7 +50,7 @@ class RunnerCutterControlNode : public rclcpp::Node {
                                           {0.15f, 0.0f, 0.0f, 0.0f});
     declare_parameter<std::vector<float>>("burn_laser_color",
                                           {0.0f, 0.0f, 1.0f, 0.0f});
-    declare_parameter<float>("burn_time_secs", 5.0);
+    declare_parameter<float>("burn_time_secs", 1.0);
     declare_parameter<bool>("enable_aiming", true);
     // Max number of times to attempt to target a detected runner to burn. An
     // attempt may fail if the runner burn point is outside the laser bounds, if


### PR DESCRIPTION
Set to 1 point per frame @ 30000 fps. Laser projector (Unity RAW 10) spec says it is able to support 30kpps.