### PR TITLE
[ros2][runner cutter control] Fix detection bounds not applied after burn

### DIFF
--- a/ros2/src/detection/src/detection_node.cpp
+++ b/ros2/src/detection/src/detection_node.cpp
@@ -705,6 +705,16 @@ class DetectionNode : public rclcpp::Node {
       }
     }
 
+    RCLCPP_INFO(
+        get_logger(),
+        "Detection started: detectionType=%d, "
+        "normalizedBounds=[x=%f, y=%f, width=%f, height=%f]",
+        static_cast<int>(request->detection_type),
+        enabledDetections_[request->detection_type].x,
+        enabledDetections_[request->detection_type].y,
+        enabledDetections_[request->detection_type].width,
+        enabledDetections_[request->detection_type].height);
+
     publishState();
     response->success = true;
   }
@@ -725,6 +735,8 @@ class DetectionNode : public rclcpp::Node {
       enabledDetections_.erase(request->detection_type);
     }
 
+    RCLCPP_INFO(get_logger(), "Detection stopped: detectionType=%d",
+                static_cast<int>(request->detection_type));
     publishState();
     response->success = true;
   }
@@ -742,6 +754,7 @@ class DetectionNode : public rclcpp::Node {
       enabledDetections_.clear();
     }
 
+    RCLCPP_INFO(get_logger(), "All detections stopped.");
     publishState();
     response->success = true;
   }

--- a/ros2/src/runner_cutter_control/src/runner_cutter_control_node.cpp
+++ b/ros2/src/runner_cutter_control/src/runner_cutter_control_node.cpp
@@ -764,6 +764,12 @@ class RunnerCutterControlNode : public rclcpp::Node {
     // topic.
     NormalizedPixelRect normalizedLaserBounds{
         calibration_->getNormalizedLaserBounds()};
+    RCLCPP_INFO(get_logger(),
+                "Runner cutter ARMED: detectionType=%d, "
+                "normalizedLaserBounds=[u=%f, v=%f, width=%f, height=%f]",
+                static_cast<int>(detectionType), normalizedLaserBounds.u,
+                normalizedLaserBounds.v, normalizedLaserBounds.width,
+                normalizedLaserBounds.height);
     detection_->startDetection(detectionType, normalizedLaserBounds);
 
     while (!taskStopSignal_) {
@@ -791,11 +797,12 @@ class RunnerCutterControlNode : public rclcpp::Node {
         continue;
       }
 
-      auto target{std::move(*targetOpt)};
+      // Temporarily disable runner detection during aim/burn if needed
       if (!enableDetectionDuringBurn) {
-        // Temporarily disable runner detection during aim/burn
         detection_->stopDetection(detectionType);
       }
+
+      auto target{std::move(*targetOpt)};
 
       // Aim
       LaserCoord laserCoord;
@@ -816,8 +823,9 @@ class RunnerCutterControlNode : public rclcpp::Node {
       // Burn
       burnTarget(target->getId(), laserCoord);
 
+      // Re-enable runner detection after burn if needed
       if (!enableDetectionDuringBurn) {
-        detection_->startDetection(detectionType);
+        detection_->startDetection(detectionType, normalizedLaserBounds);
       }
     }
   }


### PR DESCRIPTION
We disable runner detection during burn, and re-enable afterwards. During the re-enabling, we forgot to pass in the normalizedLaserBounds.