### PR TITLE
[ros2][docker] Persist logs

### DIFF
--- a/ros2/docker-compose.yaml
+++ b/ros2/docker-compose.yaml
@@ -20,6 +20,11 @@ services:
     ipc: host
     privileged: true  # gives access to all /dev/*. In the future could specify devices.
     stop_grace_period: 10s # gives ROS nodes time to shut down cleanly
+    logging:
+      driver: "local"
+      options:
+        max-size: "100m"
+        max-file: "5"
     depends_on:
       - livekit-server
       - livekit-ingress
@@ -37,6 +42,8 @@ services:
       # Keep build artifacts in volume mount to keep them across restarts while avoid polluting host
       - ros2-build:/workspaces/ros2/build
       - ros2-install:/workspaces/ros2/install
+      # Volume mount the home dir
+      - ros2-home:/root
     env_file:
       - ./.env # uses LIVEKIT_API_KEY, LIVEKIT_API_SECRET
     entrypoint: ["/workspaces/ros2/docker/dev_entrypoint.sh"]
@@ -45,6 +52,11 @@ services:
   redis:
     image: redis:8
     network_mode: host
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: unless-stopped
 
   livekit-server:
@@ -57,6 +69,11 @@ services:
       - ./src/livekit_ros2/config:/config:ro
     env_file:
       - ./.env # uses LIVEKIT_KEYS
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: unless-stopped
 
   livekit-ingress:
@@ -70,8 +87,14 @@ services:
       - ./src/livekit_ros2/config:/config:ro
     env_file:
       - ./.env # uses LIVEKIT_API_KEY, LIVEKIT_API_SECRET
+    logging:
+      driver: "local"
+      options:
+        max-size: "10m"
+        max-file: "3"
     restart: unless-stopped
 
 volumes:
   ros2-build:
   ros2-install:
+  ros2-home:

--- a/ros2/docker/build_and_run.sh
+++ b/ros2/docker/build_and_run.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -eo pipefail
 
+# Tee stdout/stderr to logfile, while making sure that SIGINT/SIGTERM are ignored
+mkdir -p /workspaces/ros2/log
+LOGFILE="/workspaces/ros2/log/runner-cutter_$(date +%Y-%m-%d_%H-%M-%S).log"
+exec > >(trap '' INT TERM; exec tee "$LOGFILE") 2>&1
+echo "[build_and_run] Logging to $LOGFILE"
+
 # Compile TensorRT engines if not already built.
 # Engines are device-specific and can't be baked into the image.
 echo "[build_and_run] Building TensorRT engines if needed..."
@@ -70,7 +76,7 @@ shutdown() {
         kill -0 "$pid" 2>/dev/null && kill -9 -"$pid" 2>/dev/null || true
     done
 
-    wait 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
     echo "[build_and_run] Shutdown complete."
 }
 
@@ -79,6 +85,6 @@ trap 'shutdown INT' INT
 trap 'shutdown TERM' TERM
 
 # Block the script indefinitely until background jobs are stopped
-wait || true
+wait "${pids[@]}" || true
 
 echo "[build_and_run] All processes stopped."


### PR DESCRIPTION
redis/livekit-server/livekit-ingress container logs use logging driver.
ros2 logs are written to ros2/log/runner-cutter_*.log