### PR TITLE
[ros2][docker] Add health checks for livekit containers

### DIFF
--- a/ros2/docker-compose.yaml
+++ b/ros2/docker-compose.yaml
@@ -26,8 +26,10 @@ services:
         max-size: "100m"
         max-file: "5"
     depends_on:
-      - livekit-server
-      - livekit-ingress
+      livekit-server:
+        condition: service_healthy
+      livekit-ingress:
+        condition: service_healthy
     environment:
       - NVIDIA_VISIBLE_DEVICES=all
       - NVIDIA_DRIVER_CAPABILITIES=all
@@ -74,6 +76,12 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:7880/ || exit 1"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
     restart: unless-stopped
 
   livekit-ingress:
@@ -92,6 +100,12 @@ services:
       options:
         max-size: "10m"
         max-file: "3"
+    healthcheck:
+      test: ["CMD-SHELL", "bash -c '</dev/tcp/localhost/8085' 2>/dev/null"]
+      interval: 2s
+      timeout: 2s
+      retries: 10
+      start_period: 5s
     restart: unless-stopped
 
 volumes:


### PR DESCRIPTION
Avoid starting ros2 container until livekit containers are healthy.

livekit-server has an http server so we can do a proper check.
With livekit-ingress, we just check if there is something listening to the tcp port.