### PR TITLE
[ros2][livekit] Remove STUN server

### DIFF
--- a/ros2/src/livekit_ros2/config/livekit_server.yaml
+++ b/ros2/src/livekit_ros2/config/livekit_server.yaml
@@ -4,6 +4,7 @@ rtc:
   tcp_port: 7881
   udp_port: 7882
   use_external_ip: false
+  stun_servers: []
   ips:
     excludes:
       - 172.16.0.0/12 # Docker bridge ranges (172.17-172.31)

--- a/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
+++ b/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
@@ -219,6 +219,7 @@ class LiveKitWhipNode(Node):
         webrtcbin.set_property(
             "bundle-policy", "max-bundle"
         )  # aggressively bundle, which typically results in fewer ICE checks and faster startup
+        webrtcbin.set_property("stun-server", "")
         self._pipeline.add(webrtcbin)
 
         # Link elements (except webrtcbin)


### PR DESCRIPTION
We need to support the following cases:
- Jetson and client browser device are connected via ethernet
- Jetson and client browser device are both connected to internet and on the same Tailscale network

In both cases, STUN is not needed.