### PR TITLE
[ros2] Remove unnecessary TAILSCALE_IP

### DIFF
--- a/apps/runner-cutter-app/next.config.mjs
+++ b/apps/runner-cutter-app/next.config.mjs
@@ -1,4 +1,5 @@
 import dotenv from "dotenv";
+import os from "node:os";
 import path from "node:path";
 
 // First, load ros2 .env
@@ -12,9 +13,22 @@ dotenv.config({
   override: true,
 });
 
+function getLocalOrigins() {
+  const origins = ["localhost"];
+  const interfaces = os.networkInterfaces();
+  for (const iface of Object.values(interfaces)) {
+    for (const addr of iface ?? []) {
+      if (!addr.internal && addr.family === "IPv4") {
+        origins.push(addr.address);
+      }
+    }
+  }
+  return origins;
+}
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  allowedDevOrigins: process.env.TAILSCALE_IP ? [process.env.TAILSCALE_IP] : [],
+  allowedDevOrigins: getLocalOrigins(),
   async headers() {
     return [
       {

--- a/ros2/docker-compose.yaml
+++ b/ros2/docker-compose.yaml
@@ -66,7 +66,7 @@ services:
     network_mode: host
     depends_on:
       - redis
-    command: ["--config", "/config/livekit_server.yaml", "--node-ip", "${TAILSCALE_IP:-}"]
+    command: ["--config", "/config/livekit_server.yaml"]
     volumes:
       - ./src/livekit_ros2/config:/config:ro
     env_file:

--- a/ros2/scripts/create_env_file.sh
+++ b/ros2/scripts/create_env_file.sh
@@ -18,16 +18,3 @@ EOF
 else
     echo "[create_env_file] .env already exists, skipping generation of LiveKit API secret"
 fi
-
-# Detect Tailscale IP that LiveKit Server will advertise to WebRTC clients
-# as an ICE host candidate, which is required for the media stream to reach
-# clients connecting via Tailscale.
-TAILSCALE_IP=$(ip -4 addr show tailscale0 2>/dev/null | sed 's|.*inet \([0-9.]*\)/.*|\1|;t;d' | head -1)
-if grep -q '^TAILSCALE_IP=' "$env_file" 2>/dev/null; then
-    # If TAILSCALE_IP already exists, replace in-place
-    sed -i "s|^TAILSCALE_IP=.*|TAILSCALE_IP=$TAILSCALE_IP|" "$env_file"
-else
-    # If TAILSCALE_IP does note exist yet in the .env file, append it
-    printf '\n# Tailscale IP advertised to WebRTC clients as ICE candidate\nTAILSCALE_IP=%s\n' "$TAILSCALE_IP" >> "$env_file"
-fi
-echo "[create_env_file] Set TAILSCALE_IP=${TAILSCALE_IP:-<not found, will auto-detect>}"


### PR DESCRIPTION
Turns out TAILSCALE_IP isn't needed. node-ip (on livekit-server) doesn't do anything if use_external_ip is false (which it is). On the NextJS side, we can compute the IPs automatically (we need alloweDevOrigins because "Cross-origin access to Next.js dev resources is blocked by default for safety."