### PR TITLE
[WIP] Fix flaky connection

### DIFF
--- a/ros2/src/livekit_ros2/config/ingress_server.yaml
+++ b/ros2/src/livekit_ros2/config/ingress_server.yaml
@@ -8,3 +8,8 @@ rtc_config:
   udp_port: 7885
   tcp_port: 7886 # optional TCP ICE fallback
   use_external_ip: false
+  stun_servers: []
+  enable_loopback_candidate: true
+  ips:
+    includes:
+      - 127.0.0.1/32 # include loopback only, since ingress only ever talks to livekit server and the livekit WHIP publisher ROS node

--- a/ros2/src/livekit_ros2/config/livekit_server.yaml
+++ b/ros2/src/livekit_ros2/config/livekit_server.yaml
@@ -5,10 +5,10 @@ rtc:
   udp_port: 7882
   use_external_ip: false
   stun_servers: []
+  enable_loopback_candidate: true
   ips:
     excludes:
-      - 172.16.0.0/12 # Docker bridge ranges (172.17-172.31)
-      - 127.0.0.0/8
+      - 172.16.0.0/12 # Docker bridge ranges
 redis:
   address: 127.0.0.1:6379
 ingress:


### PR DESCRIPTION
Ingress only ever talks to livekit server and the livekit ROS node and both use localhost URLs, so we can narrow the ingress server's ips.include to just loopback.

For livekit server, we need loopback for ingress <-> lk server, but also we need to make sure browser <-> lk server works, so we only exclude the Docker bridge ranges