### PR TITLE
[ros2][livekit] Fix ingress service ICE candidate gathering timeout

### DIFF
--- a/apps/runner-cutter-app/README.md
+++ b/apps/runner-cutter-app/README.md
@@ -24,13 +24,18 @@ Web app for laser runner cutter control and automation, built with Next.js.
 
 1.  [Optional] Set environment variables
 
-    By default, the Rosbridge websocket server URL will be set to `ws://<window.location.hostname>:9090`, and the video server URL will be set to `http://<window.location.hostname>:8080`. If you want to override those to custom URLs, you can do the following:
+    By default, the Rosbridge websocket server URL will be set to `ws://<window.location.hostname>:9090`, and the LiveKit server URL will be set to `ws://<window.location.hostname>:7880`. If will be running Rosbridge and/or LiveKit server on a remote machine, you will need to override those to custom URLs by doing the following:
 
         $ cd laser-runner-cutter/apps/runner-cutter-app
-        $ echo "NEXT_PUBLIC_ROSBRIDGE_URL=ws://localhost:9090" >> .env.local
-        $ echo "NEXT_PUBLIC_VIDEO_SERVER_URL=http://localhost:8080" >> .env.local
+        $ echo "NEXT_PUBLIC_ROSBRIDGE_URL=ws://10.95.76.2:9090" >> .env.local
+        $ echo "NEXT_PUBLIC_LIVEKIT_URL=ws://10.95.76.2:7880" >> .env.local
 
-    Change `ws://localhost:9090` to wherever Rosbridge will be running, and `http://localhost:8080` to wherever Web Video Server will be running.
+    Change `ws://10.95.76.2:9090` to wherever Rosbridge will be running, and `ws://10.95.76.2:7880` to wherever the LiveKit server will be running.
+
+    In addition, if you are running LiveKit server on a remote machine, you will need to make sure that you have LIVEKIT_API_KEY and LIVEKIT_API_SECRET defined. These need to match exactly with the ones used by the LiveKit Ingress server and the LiveKitWhipNode (on whichever machine is running LiveKit, check laser-runner-cutter/ros2/.env).
+
+        $ echo "LIVEKIT_API_KEY=devkey" >> .env.local
+        $ echo 'LIVEKIT_API_SECRET="<your API secret>"' >> .env.local
 
 1.  Run the setup script:
 

--- a/ros2/README.md
+++ b/ros2/README.md
@@ -23,14 +23,6 @@ sudo tailscale up
 # Follow the URL printed to log in and approve the device
 ```
 
-Once connected, update `.env` with the Tailscale IP (the bootstrap script ran `create_env_file.sh` before Tailscale was connected, so this needs to be re-run):
-
-```sh
-~/laser-runner-cutter/ros2/scripts/create_env_file.sh
-```
-
-If the Tailscale IP ever changes (e.g. after re-joining the network), re-run `create_env_file.sh` and restart the Docker containers.
-
 ### Using Helios DAC on Linux
 
 Linux systems require udev rules to allow access to USB devices without root privileges. This is already set up as part of the auto-install process above. Make sure that the user account communicating with the DAC is in the `plugdev` group.

--- a/ros2/docker-compose.yaml
+++ b/ros2/docker-compose.yaml
@@ -90,9 +90,12 @@ services:
     depends_on:
       - livekit-server
       - redis
+      - dns-blackhole
     command: ["--config", "/config/ingress_server.yaml"]
     volumes:
       - ./src/livekit_ros2/config:/config:ro
+      # Ingress needs to use the dnsmasq DNS blackhole
+      - ./src/livekit_ros2/config/ingress_resolv.conf:/etc/resolv.conf:ro
     env_file:
       - ./.env # uses LIVEKIT_API_KEY, LIVEKIT_API_SECRET
     logging:
@@ -106,6 +109,22 @@ services:
       timeout: 2s
       retries: 10
       start_period: 5s
+    restart: unless-stopped
+
+  # Ingress's WHIP-side ICE agent gathers server-reflexive candidates against these hardcoded
+  # public STUN servers regardless of ingress_server.yaml's stun_servers: [] setting.
+  # The issue is that if there is no working upstream DNS path (such as when WiFi is disabled)
+  # we eventually hit Ingress's hardcoded timeout.
+  # Since Ingress's WHIP connections are always same-host in our case, STUN/srflx candidates
+  # are not needed. Thus, the solution is a dnsmasq instance so that the STUN hostnames'
+  # resolution fails instantly and deterministically in every network state.
+  # Config is supplied via a mounted dnsmasq.conf rather than `command:` args due to how the
+  # container's entrypoint works.
+  dns-blackhole:
+    image: dockurr/dnsmasq
+    network_mode: host
+    volumes:
+      - ./src/livekit_ros2/config/dnsmasq.conf:/etc/dnsmasq.conf:ro
     restart: unless-stopped
 
 volumes:

--- a/ros2/src/livekit_ros2/config/dnsmasq.conf
+++ b/ros2/src/livekit_ros2/config/dnsmasq.conf
@@ -1,0 +1,7 @@
+no-hosts
+bind-interfaces
+listen-address=127.0.0.2
+port=53
+server=/global.stun.twilio.com/
+server=/stun.l.google.com/
+server=/stun1.l.google.com/

--- a/ros2/src/livekit_ros2/config/ingress_resolv.conf
+++ b/ros2/src/livekit_ros2/config/ingress_resolv.conf
@@ -1,0 +1,1 @@
+nameserver 127.0.0.2

--- a/ros2/src/livekit_ros2/config/ingress_server.yaml
+++ b/ros2/src/livekit_ros2/config/ingress_server.yaml
@@ -8,3 +8,9 @@ rtc_config:
   udp_port: 7885
   tcp_port: 7886 # optional TCP ICE fallback
   use_external_ip: false
+  stun_servers: []
+  ips:
+    # Ingress's WHIP connection is always same-host
+    includes:
+      - 10.0.0.0/8
+      - 192.168.0.0/16

--- a/ros2/src/livekit_ros2/config/livekit_server.yaml
+++ b/ros2/src/livekit_ros2/config/livekit_server.yaml
@@ -8,7 +8,8 @@ rtc:
   ips:
     excludes:
       - 172.16.0.0/12 # Docker bridge ranges (172.17-172.31)
-      - 127.0.0.0/8
+      - 169.254.0.0/16 # link-local IPv4
+      - fe80::/10 # link-local IPv6
 redis:
   address: 127.0.0.1:6379
 ingress:

--- a/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
+++ b/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
@@ -1,6 +1,7 @@
 import asyncio
 import os
 import threading
+import time
 from typing import Optional
 from urllib.parse import urlparse
 
@@ -20,6 +21,16 @@ gi.require_version("GLib", "2.0")
 gi.require_version("GstSdp", "1.0")
 gi.require_version("GstWebRTC", "1.0")
 from gi.repository import GLib, Gst, GstSdp, GstWebRTC
+
+# If ICE gathering has not completed within this many seconds of negotiation
+# starting, we assume it is stuck, and rebuild the pipeline.
+ICE_GATHERING_TIMEOUT_SEC = 15
+
+# Retry with exponential backoff for the WHIP POST, in case the ingress server may not be
+# reachable yet during a boot-time network race.
+WHIP_POST_MAX_ATTEMPTS = 5
+WHIP_POST_RETRY_BASE_DELAY_SEC = 2
+WHIP_POST_RETRY_MAX_DELAY_SEC = 30
 
 
 async def get_or_create_whip_endpoint(
@@ -96,6 +107,7 @@ class LiveKitWhipNode(Node):
         self._pipeline = None
         self._appsrc = None
         self._whip_resource_url: Optional[str] = None
+        self._ice_gathering_complete = False
 
         # Get WHIP URL
         livekit_api_key = os.environ["LIVEKIT_API_KEY"]
@@ -247,6 +259,8 @@ class LiveKitWhipNode(Node):
             "notify::ice-gathering-state",
             self._on_ice_gathering_state,
         )
+        webrtcbin.connect("notify::connection-state", self._on_connection_state)
+        webrtcbin.connect("notify::ice-connection-state", self._on_ice_state)
 
         self.get_logger().info("Pipeline created")
 
@@ -271,10 +285,28 @@ class LiveKitWhipNode(Node):
         """
 
         self.get_logger().info("Negotiation needed. Creating offer")
+        self._ice_gathering_complete = False
         promise = Gst.Promise.new_with_change_func(
             self._on_offer_created, webrtcbin, None
         )
         webrtcbin.emit("create-offer", None, promise)
+        GLib.timeout_add_seconds(
+            ICE_GATHERING_TIMEOUT_SEC, self._on_ice_gathering_timeout, webrtcbin
+        )
+
+    def _on_ice_gathering_timeout(self, webrtcbin):
+        """
+        Called after ICE_GATHERING_TIMEOUT_SEC to check whether ICE gathering has completed. If not,
+        rebuilds the pipeline.
+        """
+
+        if not self._ice_gathering_complete:
+            self.get_logger().error(
+                f"ICE gathering did not complete within {ICE_GATHERING_TIMEOUT_SEC}s. "
+                "Rebuilding pipeline"
+            )
+            self._restart_pipeline()
+        return GLib.SOURCE_REMOVE
 
     def _on_offer_created(self, promise, webrtcbin, _):
         """
@@ -296,6 +328,7 @@ class LiveKitWhipNode(Node):
         state = webrtcbin.get_property("ice-gathering-state")
         if int(state) == int(GstWebRTC.WebRTCICEGatheringState.COMPLETE):
             self.get_logger().info(f"ICE gathering complete")
+            self._ice_gathering_complete = True
             self._send_offer_via_whip(webrtcbin)
 
     def _send_offer_via_whip(self, webrtcbin):
@@ -314,22 +347,42 @@ class LiveKitWhipNode(Node):
             return
         offer_sdp_text = local.sdp.as_text()
 
-        self.get_logger().info(f"POSTing offer to WHIP endpoint: {self._whip_url}")
-        try:
-            resp = requests.post(
-                self._whip_url,
-                data=offer_sdp_text,
-                headers={"Content-Type": "application/sdp"},
-                timeout=10,
+        resp = None
+        for attempt in range(1, WHIP_POST_MAX_ATTEMPTS + 1):
+            self.get_logger().info(
+                f"POSTing offer to WHIP endpoint (attempt {attempt}/{WHIP_POST_MAX_ATTEMPTS}): "
+                f"{self._whip_url}"
             )
-        except Exception as e:
-            self.get_logger().error(f"WHIP POST failed: {e}")
-            return
+            try:
+                resp = requests.post(
+                    self._whip_url,
+                    data=offer_sdp_text,
+                    headers={"Content-Type": "application/sdp"},
+                    timeout=10,
+                )
+                if resp.status_code in (200, 201):
+                    break
+                self.get_logger().error(
+                    f"WHIP POST HTTP {resp.status_code}: {resp.text[:200]}"
+                )
+            except Exception as e:
+                self.get_logger().error(f"WHIP POST failed: {e}")
+                resp = None
 
-        if resp.status_code not in (200, 201):
+            if attempt < WHIP_POST_MAX_ATTEMPTS:
+                # Exponential backoff
+                delay = min(
+                    WHIP_POST_RETRY_BASE_DELAY_SEC * (2 ** (attempt - 1)),
+                    WHIP_POST_RETRY_MAX_DELAY_SEC,
+                )
+                self.get_logger().info(f"Retrying WHIP POST in {delay}s...")
+                time.sleep(delay)
+
+        if resp is None or resp.status_code not in (200, 201):
             self.get_logger().error(
-                f"WHIP POST HTTP {resp.status_code}: {resp.text[:200]}"
+                f"WHIP POST failed after {WHIP_POST_MAX_ATTEMPTS} attempts. Rebuilding pipeline"
             )
+            self._restart_pipeline()
             return
 
         self._whip_resource_url = resp.headers.get("Location", None)
@@ -371,6 +424,43 @@ class LiveKitWhipNode(Node):
             6: "CLOSED",
         }.get(state, f"UNKNOWN({state})")
         self.get_logger().info(f"ICE connection state: {state_name}")
+        if int(state) == int(GstWebRTC.WebRTCICEConnectionState.FAILED):
+            self.get_logger().error("ICE connection failed. Rebuilding pipeline")
+            self._restart_pipeline()
+
+    def _teardown_whip_resource(self):
+        """
+        Deletes the current WHIP resource on the ingress server, if one exists.
+        """
+
+        if not self._whip_resource_url:
+            return
+        try:
+            parsed_url = urlparse(self._whip_url)
+            full_whip_resource_url = (
+                parsed_url.scheme + "://" + parsed_url.netloc + self._whip_resource_url
+            )
+            requests.delete(full_whip_resource_url, timeout=3)
+        except Exception as e:
+            self.get_logger().warn(f"WHIP DELETE failed: {e}")
+        finally:
+            self._whip_resource_url = None
+
+    def _restart_pipeline(self):
+        """
+        Tears down the current pipeline and WHIP resource so the next incoming
+        frame rebuilds the pipeline and renegotiates from scratch.
+        """
+
+        self._teardown_whip_resource()
+        if self._pipeline:
+            try:
+                self._pipeline.set_state(Gst.State.NULL)
+            except Exception:
+                pass
+        self._pipeline = None
+        self._appsrc = None
+        self._ice_gathering_complete = False
 
     # endregion
 
@@ -381,7 +471,7 @@ class LiveKitWhipNode(Node):
         if t == Gst.MessageType.ERROR:
             err, dbg = message.parse_error()
             self.get_logger().error(f"GStreamer ERROR: {err} debug:{dbg}")
-            self._pipeline.set_state(Gst.State.NULL)
+            self._restart_pipeline()
         elif t == Gst.MessageType.WARNING:
             w, dbg = message.parse_warning()
             self.get_logger().warn(f"GStreamer WARN: {w} debug:{dbg}")
@@ -436,20 +526,7 @@ class LiveKitWhipNode(Node):
             self.get_logger().warn(f"push-buffer -> {flow}")
 
     def destroy_node(self):
-        # Tear down WHIP resource
-        try:
-            if self._whip_resource_url:
-                headers = {}
-                parsed_url = urlparse(self._whip_url)
-                full_whip_resource_url = (
-                    parsed_url.scheme
-                    + "://"
-                    + parsed_url.netloc
-                    + self._whip_resource_url
-                )
-                requests.delete(full_whip_resource_url, headers=headers, timeout=3)
-        except Exception as e:
-            self.get_logger().warn(f"WHIP DELETE failed: {e}")
+        self._teardown_whip_resource()
 
         # GStreamer shutdown
         try:


### PR DESCRIPTION
## Issue

On reboot, the Docker containers all come back online automatically. ICE candidate gathering is triggered right when the cameras are enabled and started streaming. However, consistently, the LiveKit ingress service times out (after 5s) with "timed out while waiting for ICE candidate gathering", but ONLY when WiFi is disabled on boot. When machine is booted with Wifi enabled, the ICE candidate gathering completes successfully. Also, manually doing docker compose down then up is always successful.

## Root cause

Ingress's WHIP-side ICE agent gathers server-reflexive candidates against hardcoded public STUN servers regardless of ingress_server.yaml's stun_servers: [] setting. If there is no working upstream DNS path (such as when WiFi is disabled), we eventually hit Ingress's hardcoded timeout.

## Solution

We start up a dnsmasq instance and configure the ingress container to use it for DNS resolution. This causes the STUN hostnames' resolution fails instantly and deterministically in every network state - this is fine for ingress because ingress only talks to same-host services.