### PR TITLE
[ros2][camera control] Add QoS override for rosbag playback

### DIFF
--- a/ros2/src/camera_control/src/camera_control_node.cpp
+++ b/ros2/src/camera_control/src/camera_control_node.cpp
@@ -598,6 +598,8 @@ class CameraControlNode : public rclcpp::Node {
         // on the camera capture thread, so we favor write throughput over
         // maximum compression ratio.
         storageOptions.storage_preset_profile = "zstd_fast";
+        storageOptions.max_bagfile_size =
+            4ULL * 1024 * 1024 * 1024;  // 4GB per file
         bagWriter_->open(storageOptions);
 
         tf2_msgs::msg::TFMessage tfMsg;

--- a/ros2/src/camera_control/test/config/rosbag_replay_qos_overrides.yaml
+++ b/ros2/src/camera_control/test/config/rosbag_replay_qos_overrides.yaml
@@ -1,0 +1,5 @@
+/tf_static:
+  durability: transient_local
+  history: keep_last
+  depth: 100
+  reliability: reliable

--- a/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
+++ b/ros2/src/livekit_ros2/livekit_ros2/livekit_whip_node.py
@@ -433,6 +433,7 @@ class TopicStream:
         self._pipeline = None
         self._appsrc = None
         self._ice_gathering_complete = False
+        self._start_time_ns = None
 
     # endregion
 
@@ -479,14 +480,14 @@ class TopicStream:
         buf = Gst.Buffer.new_allocate(None, len(data), None)
         buf.fill(0, data)
 
+        # Use wall-clock arrival time (not the source's header.stamp) so pts reflects
+        # actual delivery timing and stays monotonic regardless of upstream timestamp
+        # behavior (which could happen with a looped/replayed rosbag, for example).
+        now_ns = time.monotonic_ns()
         if self._start_time_ns is None:
-            self._start_time_ns = (
-                msg.header.stamp.sec * 1_000_000_000 + msg.header.stamp.nanosec
-            )
+            self._start_time_ns = now_ns
 
-        timestamp_ns = (  # Assigns ROS timestamp to video frame
-            msg.header.stamp.sec * 1_000_000_000 + msg.header.stamp.nanosec
-        ) - self._start_time_ns
+        timestamp_ns = now_ns - self._start_time_ns
         buf.pts = timestamp_ns
         buf.dts = timestamp_ns
         buf.duration = Gst.CLOCK_TIME_NONE


### PR DESCRIPTION
When we are writing the rosbag, it has no information on the QoS of the topic publishers. When replaying the rosbag, we need to tell it what QoS to use, so that the subscribers can determine that it is compatible with their own QoS.

How to use this:
```
ros2 bag play /root/runner_cutter/camera/bag_20260810154211924/ --qos-profile-overrides-path src/camera_control/test/config/rosbag_replay_qos_overrides.yaml --loop
```